### PR TITLE
changed Always to inheret from StructuralStatement

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -295,7 +295,7 @@ class Star : Node {
   std::string toString() { return "*"; };
 };
 
-class Always : public Statement {
+class Always : public StructuralStatement {
   std::vector<std::variant<Identifier *, PosEdge *, NegEdge *, Star *>>
       sensitivity_list;
   std::vector<std::variant<BehavioralStatement *, Declaration *>> body;
@@ -316,14 +316,13 @@ class Always : public Statement {
 class Module : public Node {
   std::string name;
   std::vector<Port *> ports;
-  std::vector<std::variant<Always *, StructuralStatement *, Declaration *>>
-      body;
+  std::vector<std::variant<StructuralStatement *, Declaration *>> body;
   std::map<std::string, NumericLiteral *> parameters;
 
  public:
   Module(
       std::string name, std::vector<Port *> ports,
-      std::vector<std::variant<Always *, StructuralStatement *, Declaration *>>
+      std::vector<std::variant<StructuralStatement *, Declaration *>>
           body,
       std::map<std::string, NumericLiteral *> parameters)
       : name(name), ports(ports), body(body), parameters(parameters){};

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -234,12 +234,12 @@ std::string ModuleInstantiation::toString() {
 }
 
 std::string Declaration::toString() {
-  return decl + " " + variant_to_string(value);
+  return decl + " " + variant_to_string(value) + ";";
 }
 
 std::string Assign::toString() {
   return prefix + variant_to_string(target) + " " + symbol + " " +
-         value->toString();
+         value->toString() + ";";
 }
 
 std::string Always::toString() {
@@ -258,7 +258,7 @@ std::string Always::toString() {
   for (auto statement : body) {
     always_str +=
         variant_to_string<BehavioralStatement *, Declaration *>(statement) +
-        ";\n";
+        "\n";
   }
 
   always_str += "end\n";

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -200,8 +200,7 @@ std::string Module::toString() {
   // emit body
   for (auto statement : body) {
     module_str +=
-        variant_to_string<Always *, StructuralStatement *, Declaration *>(
-            statement) +
+        variant_to_string<StructuralStatement *, Declaration *>(statement) +
         ";\n";
   }
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -201,7 +201,7 @@ std::string Module::toString() {
   for (auto statement : body) {
     module_str +=
         variant_to_string<StructuralStatement *, Declaration *>(statement) +
-        ";\n";
+        "\n";
   }
 
   module_str += "endmodule\n";
@@ -229,7 +229,7 @@ std::string ModuleInstantiation::toString() {
     }
     module_inst_str += join(param_strs, ", ");
   }
-  module_inst_str += ")";
+  module_inst_str += ");";
   return module_inst_str;
 }
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -171,7 +171,7 @@ TEST(BasicTests, TestModuleInst) {
 
   EXPECT_EQ(module_inst.toString(),
             "test_module #(.param0(32'd0), .param1(32'd1)) "
-            "test_module_inst(.a(a), .b(b[32'd0]), .c(c[32'd31:32'd0]))");
+            "test_module_inst(.a(a), .b(b[32'd0]), .c(c[32'd31:32'd0]));");
 }
 
 TEST(BasicTests, TestModule) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -236,35 +236,35 @@ TEST(BasicTests, TestModule) {
 TEST(BasicTests, TestDeclaration) {
   vAST::Identifier a("a");
   vAST::Wire wire(&a);
-  EXPECT_EQ(wire.toString(), "wire a");
+  EXPECT_EQ(wire.toString(), "wire a;");
 
   vAST::Reg reg(&a);
-  EXPECT_EQ(reg.toString(), "reg a");
+  EXPECT_EQ(reg.toString(), "reg a;");
 
   vAST::Identifier id("x");
   vAST::NumericLiteral n("0");
   vAST::Index index(&id, &n);
   vAST::Wire wire_index(&index);
-  EXPECT_EQ(wire_index.toString(), "wire x[32'd0]");
+  EXPECT_EQ(wire_index.toString(), "wire x[32'd0];");
 
   vAST::NumericLiteral high("31");
   vAST::NumericLiteral low("0");
   vAST::Slice slice(&id, &high, &low);
   vAST::Reg reg_slice(&slice);
-  EXPECT_EQ(reg_slice.toString(), "reg x[32'd31:32'd0]");
+  EXPECT_EQ(reg_slice.toString(), "reg x[32'd31:32'd0];");
 }
 
 TEST(BasicTests, TestAssign) {
   vAST::Identifier a("a");
   vAST::Identifier b("b");
   vAST::ContinuousAssign cont_assign(&a, &b);
-  EXPECT_EQ(cont_assign.toString(), "assign a = b");
+  EXPECT_EQ(cont_assign.toString(), "assign a = b;");
 
   vAST::BlockingAssign blocking_assign(&a, &b);
-  EXPECT_EQ(blocking_assign.toString(), "a = b");
+  EXPECT_EQ(blocking_assign.toString(), "a = b;");
 
   vAST::NonBlockingAssign non_blocking_assign(&a, &b);
-  EXPECT_EQ(non_blocking_assign.toString(), "a <= b");
+  EXPECT_EQ(non_blocking_assign.toString(), "a <= b;");
 }
 
 TEST(BasicTests, TestAlways) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -185,8 +185,7 @@ TEST(BasicTests, TestModule) {
 
   std::vector<vAST::Port *> ports = {&i_port, &o_port};
 
-  std::vector<std::variant<vAST::Always *, vAST::StructuralStatement *,
-                           vAST::Declaration *>>
+  std::vector<std::variant<vAST::StructuralStatement *,vAST::Declaration *>>
       body;
 
   std::string module_name = "other_module";
@@ -319,8 +318,7 @@ TEST(BasicTests, File) {
 
   std::vector<vAST::Port *> ports = {&i_port, &o_port};
 
-  std::vector<std::variant<vAST::Always *, vAST::StructuralStatement *,
-                           vAST::Declaration *>>
+  std::vector<std::variant<vAST::StructuralStatement *, vAST::Declaration *>>
       body;
 
   std::string module_name = "other_module";


### PR DESCRIPTION
The always block itself is a structural statement (in my opinion). I do not think we need to treat it differently than other structural statements. This also simplifies the AST slightly.