### PR TITLE
Add support for a string module definition

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -322,15 +322,17 @@ class Module : public Node {
   std::vector<std::variant<StructuralStatement *, Declaration *>> body;
   Parameters parameters;
   std::string emitModuleHeader();
+  // Protected initializer that is used by the StringModule subclass which
+  // overrides the `body` field (but reuses the other fields)
+  Module(std::string name, std::vector<Port *> ports, 
+         Parameters parameters)
+      : name(name), ports(ports), parameters(parameters){};
 
  public:
   Module(std::string name, std::vector<Port *> ports,
          std::vector<std::variant<StructuralStatement *, Declaration *>> body,
          Parameters parameters)
       : name(name), ports(ports), body(body), parameters(parameters){};
-  Module(std::string name, std::vector<Port *> ports, 
-         Parameters parameters)
-      : name(name), ports(ports), parameters(parameters){};
 
   std::string toString();
 };

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -316,17 +316,32 @@ class Always : public StructuralStatement {
 };
 
 class Module : public Node {
+ protected:
   std::string name;
   std::vector<Port *> ports;
   std::vector<std::variant<StructuralStatement *, Declaration *>> body;
   Parameters parameters;
+  std::string emitModuleHeader();
 
  public:
   Module(std::string name, std::vector<Port *> ports,
          std::vector<std::variant<StructuralStatement *, Declaration *>> body,
          Parameters parameters)
       : name(name), ports(ports), body(body), parameters(parameters){};
+  Module(std::string name, std::vector<Port *> ports, 
+         Parameters parameters)
+      : name(name), ports(ports), parameters(parameters){};
 
+  std::string toString();
+};
+
+class StringModule : public Module {
+  std::string body;
+
+ public:
+  StringModule(std::string name, std::vector<Port *> ports, std::string body,
+               Parameters parameters)
+      : Module(name, ports, parameters), body(body){};
   std::string toString();
 };
 

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -315,14 +315,16 @@ class Always : public StructuralStatement {
   std::string toString();
 };
 
-class Module : public Node {
+class AbstractModule : public Node {};
+
+class Module : public AbstractModule {
  protected:
   std::string name;
   std::vector<Port *> ports;
   std::vector<std::variant<StructuralStatement *, Declaration *>> body;
   Parameters parameters;
   std::string emitModuleHeader();
-  // Protected initializer that is used by the StringModule subclass which
+  // Protected initializer that is used by the StringBodyModule subclass which
   // overrides the `body` field (but reuses the other fields)
   Module(std::string name, std::vector<Port *> ports, 
          Parameters parameters)
@@ -337,21 +339,28 @@ class Module : public Node {
   std::string toString();
 };
 
-class StringModule : public Module {
+class StringBodyModule : public Module {
   std::string body;
 
  public:
-  StringModule(std::string name, std::vector<Port *> ports, std::string body,
+  StringBodyModule(std::string name, std::vector<Port *> ports, std::string body,
                Parameters parameters)
       : Module(name, ports, parameters), body(body){};
   std::string toString();
 };
 
+class StringModule : public AbstractModule {
+  std::string definition;
+ public:
+  StringModule(std::string definition) : definition(definition){};
+  std::string toString() { return definition; };
+};
+
 class File : public Node {
-  std::vector<Module *> modules;
+  std::vector<AbstractModule *> modules;
 
  public:
-  File(std::vector<Module *> modules) : modules(modules){};
+  File(std::vector<AbstractModule *> modules) : modules(modules){};
   std::string toString();
 };
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -213,7 +213,7 @@ std::string Module::toString() {
   return module_str;
 }
 
-std::string StringModule::toString() {
+std::string StringBodyModule::toString() {
   std::string module_str = "";
   module_str += emitModuleHeader();
   module_str += body;

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -174,28 +174,33 @@ std::string join(std::vector<std::string> vec, std::string separator) {
   return result;
 }
 
-std::string Module::toString() {
-  std::string module_str = "";
-  module_str += "module " + name;
+std::string Module::emitModuleHeader() {
+  std::string module_header_str = "module " + name;
 
   // emit parameter string
   if (!parameters.empty()) {
-    module_str += " #(";
+    module_header_str += " #(";
     std::vector<std::string> param_strs;
     for (auto it : parameters) {
       param_strs.push_back("parameter " + it.first->toString() + " = " +
                            it.second->toString());
     }
-    module_str += join(param_strs, ", ");
-    module_str += ")";
+    module_header_str += join(param_strs, ", ");
+    module_header_str += ")";
   }
 
   // emit port string
-  module_str += " (";
+  module_header_str += " (";
   std::vector<std::string> ports_strs;
   for (auto it : ports) ports_strs.push_back(it->toString());
-  module_str += join(ports_strs, ", ");
-  module_str += ");\n";
+  module_header_str += join(ports_strs, ", ");
+  module_header_str += ");\n";
+  return module_header_str;
+}
+
+std::string Module::toString() {
+  std::string module_str = "";
+  module_str += emitModuleHeader();
 
   // emit body
   for (auto statement : body) {
@@ -205,6 +210,14 @@ std::string Module::toString() {
   }
 
   module_str += "endmodule\n";
+  return module_str;
+}
+
+std::string StringModule::toString() {
+  std::string module_str = "";
+  module_str += emitModuleHeader();
+  module_str += body;
+  module_str += "\nendmodule\n";
   return module_str;
 }
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -152,7 +152,7 @@ TEST(BasicTests, TestModuleInst) {
 
   vAST::Identifier param0("param0");
   vAST::Identifier param1("param1");
-  vAST::Parameters parameters = {{&param0, &zero},{&param1,&one}};
+  vAST::Parameters parameters = {{&param0, &zero}, {&param1, &one}};
 
   std::string instance_name = "test_module_inst";
   vAST::Identifier a("a");
@@ -186,7 +186,7 @@ TEST(BasicTests, TestModule) {
 
   std::vector<vAST::Port *> ports = {&i_port, &o_port};
 
-  std::vector<std::variant<vAST::StructuralStatement *,vAST::Declaration *>>
+  std::vector<std::variant<vAST::StructuralStatement *, vAST::Declaration *>>
       body;
 
   std::string module_name = "other_module";
@@ -233,6 +233,14 @@ TEST(BasicTests, TestModule) {
       ".param1(32'd1)) other_module_inst(.a(a), .b(b[32'd0]), "
       ".c(c[32'd31:32'd0]));\nendmodule\n";
   EXPECT_EQ(module_with_params.toString(), expected_str);
+
+  std::string string_body = "reg d;\nassign d = a + b;\nassign c = d;";
+  vAST::StringModule string_module(name, ports, string_body, parameters);
+  expected_str =
+      "module test_module #(parameter param0 = 32'd0, parameter param1 = "
+      "32'd1) (input i, output o);\nreg d;\nassign d = a + b;\nassign c = "
+      "d;\nendmodule\n";
+  EXPECT_EQ(string_module.toString(), expected_str);
 }
 
 TEST(BasicTests, TestDeclaration) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -235,11 +235,14 @@ TEST(BasicTests, TestModule) {
   EXPECT_EQ(module_with_params.toString(), expected_str);
 
   std::string string_body = "reg d;\nassign d = a + b;\nassign c = d;";
-  vAST::StringModule string_module(name, ports, string_body, parameters);
+  vAST::StringBodyModule string_body_module(name, ports, string_body, parameters);
   expected_str =
       "module test_module #(parameter param0 = 32'd0, parameter param1 = "
       "32'd1) (input i, output o);\nreg d;\nassign d = a + b;\nassign c = "
       "d;\nendmodule\n";
+  EXPECT_EQ(string_body_module.toString(), expected_str);
+
+  vAST::StringModule string_module(expected_str);
   EXPECT_EQ(string_module.toString(), expected_str);
 }
 
@@ -361,7 +364,7 @@ TEST(BasicTests, File) {
   vAST::Module module("test_module0", ports, body, parameters);
   parameters = {{&param0, &zero}, {&param1, &one}};
   vAST::Module module_with_params("test_module1", ports, body, parameters);
-  std::vector<vAST::Module *> modules;
+  std::vector<vAST::AbstractModule *> modules;
   modules.push_back(&module);
   modules.push_back(&module_with_params);
   vAST::File file(modules);


### PR DESCRIPTION
Useful for compiling blackbox verilog represented as strings (needed for the coreir backend).