### PR TITLE
Separate port/wire/reg declaration from slicing

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -178,10 +178,21 @@ enum PortType { WIRE, REG };
 
 class AbstractPort : public Node {};
 
+class Vector : public Node {
+  Identifier *id;
+  Expression *msb;
+  Expression *lsb;
+
+ public:
+  Vector(Identifier *id, Expression *msb, Expression *lsb)
+      : id(id), msb(msb), lsb(lsb){};
+  std::string toString() override;
+};
+
 class Port : public AbstractPort {
   // Required
   // `<name>` or `<name>[n]` or `name[n:m]`
-  std::variant<Identifier *, Index *, Slice *> value;
+  std::variant<Identifier *, Vector *> value;
 
   // technically the following are optional (e.g. port direction/data type
   // can be declared in the body of the definition), but for now let's force
@@ -191,7 +202,7 @@ class Port : public AbstractPort {
   PortType data_type;
 
  public:
-  Port(std::variant<Identifier *, Index *, Slice *> value, Direction direction,
+  Port(std::variant<Identifier *, Vector *> value, Direction direction,
        PortType data_type)
       : value(value), direction(direction), data_type(data_type){};
   std::string toString();
@@ -258,9 +269,9 @@ class ModuleInstantiation : public StructuralStatement {
 class Declaration : public Node {
  protected:
   std::string decl;
-  std::variant<Identifier *, Index *, Slice *> value;
+  std::variant<Identifier *, Vector *> value;
 
-  Declaration(std::variant<Identifier *, Index *, Slice *> value,
+  Declaration(std::variant<Identifier *, Vector *> value,
               std::string decl)
       : decl(decl), value(value){};
 
@@ -270,13 +281,13 @@ class Declaration : public Node {
 
 class Wire : public Declaration {
  public:
-  Wire(std::variant<Identifier *, Index *, Slice *> value)
+  Wire(std::variant<Identifier *, Vector *> value)
       : Declaration(value, "wire"){};
 };
 
 class Reg : public Declaration {
  public:
-  Reg(std::variant<Identifier *, Index *, Slice *> value)
+  Reg(std::variant<Identifier *, Vector *> value)
       : Declaration(value, "reg"){};
 };
 
@@ -361,7 +372,8 @@ class Module : public AbstractModule {
   std::string emitModuleHeader();
   // Protected initializer that is used by the StringBodyModule subclass which
   // overrides the `body` field (but reuses the other fields)
-  Module(std::string name, std::vector<AbstractPort *> ports, Parameters parameters)
+  Module(std::string name, std::vector<AbstractPort *> ports,
+         Parameters parameters)
       : name(name), ports(ports), parameters(parameters){};
 
  public:

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -269,9 +269,9 @@ class ModuleInstantiation : public StructuralStatement {
 class Declaration : public Node {
  protected:
   std::string decl;
-  std::variant<Identifier *, Vector *> value;
+  std::variant<Identifier *, Index *, Slice *, Vector *> value;
 
-  Declaration(std::variant<Identifier *, Vector *> value,
+  Declaration(std::variant<Identifier *, Index *, Slice *, Vector *> value,
               std::string decl)
       : decl(decl), value(value){};
 
@@ -281,13 +281,13 @@ class Declaration : public Node {
 
 class Wire : public Declaration {
  public:
-  Wire(std::variant<Identifier *, Vector *> value)
+  Wire(std::variant<Identifier *, Index *, Slice *, Vector *> value)
       : Declaration(value, "wire"){};
 };
 
 class Reg : public Declaration {
  public:
-  Reg(std::variant<Identifier *, Vector *> value)
+  Reg(std::variant<Identifier *, Index *, Slice *, Vector *> value)
       : Declaration(value, "reg"){};
 };
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -4,22 +4,31 @@ namespace verilogAST {
 std::string NumericLiteral::toString() {
   std::string signed_str = _signed ? "s" : "";
 
-  char radix_str;
+  std::string radix_str;
   switch (radix) {
     case BINARY:
-      radix_str = 'b';
+      radix_str = "b";
       break;
     case OCTAL:
-      radix_str = 'o';
+      radix_str = "o";
       break;
     case HEX:
-      radix_str = 'h';
+      radix_str = "h";
       break;
     case DECIMAL:
-      radix_str = 'd';
+      radix_str = "";
       break;
   }
-  return std::to_string(size) + "'" + signed_str + radix_str + value;
+  std::string size_str = std::to_string(size);
+  if (size_str == "32") {
+      size_str = "";
+  }
+
+  std::string separator = "";
+  if (size_str + signed_str + radix_str != "") {
+      separator = "'";
+  }
+  return size_str + separator + signed_str + radix_str + value;
 }
 
 std::string Identifier::toString() { return value; }

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -35,6 +35,10 @@ std::string Slice::toString() {
          low_index->toString() + ']';
 }
 
+std::string Vector::toString() {
+  return "[" + msb->toString() + ':' + lsb->toString() + "] " + id->toString();
+}
+
 std::string BinaryOp::toString() {
   std::string op_str;
   switch (op) {
@@ -141,7 +145,7 @@ std::string variant_to_string(std::variant<Ts...> value) {
 
 std::string Port::toString() {
   std::string value_str =
-      variant_to_string<Identifier *, Index *, Slice *>(value);
+      variant_to_string<Identifier *, Vector *>(value);
   std::string direction_str;
   switch (direction) {
     case INPUT:

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -277,9 +277,17 @@ TEST(BasicTests, TestDeclaration) {
   vAST::Identifier id("x");
   vAST::NumericLiteral high("31");
   vAST::NumericLiteral low("0");
-  vAST::Vector slice(&id, &high, &low);
+  vAST::Slice slice(&id, &high, &low);
   vAST::Reg reg_slice(&slice);
-  EXPECT_EQ(reg_slice.toString(), "reg [31:0] x;");
+  EXPECT_EQ(reg_slice.toString(), "reg x[31:0];");
+
+  vAST::Index index(&id, &high);
+  vAST::Reg reg_index(&index);
+  EXPECT_EQ(reg_index.toString(), "reg x[31];");
+
+  vAST::Vector vec(&id, &high, &low);
+  vAST::Reg reg_vec(&vec);
+  EXPECT_EQ(reg_vec.toString(), "reg [31:0] x;");
 }
 
 TEST(BasicTests, TestAssign) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -7,10 +7,10 @@ namespace {
 
 TEST(BasicTests, TestNumericLiteral) {
   vAST::NumericLiteral n0("23", 16, false, vAST::DECIMAL);
-  EXPECT_EQ(n0.toString(), "16'd23");
+  EXPECT_EQ(n0.toString(), "16'23");
 
   vAST::NumericLiteral n1("DEADBEEF", 32, false, vAST::HEX);
-  EXPECT_EQ(n1.toString(), "32'hDEADBEEF");
+  EXPECT_EQ(n1.toString(), "'hDEADBEEF");
 
   vAST::NumericLiteral n2("011001", 6, false, vAST::BINARY);
   EXPECT_EQ(n2.toString(), "6'b011001");
@@ -19,16 +19,16 @@ TEST(BasicTests, TestNumericLiteral) {
   EXPECT_EQ(n3.toString(), "24'o764");
 
   vAST::NumericLiteral n4("764", 8, false);
-  EXPECT_EQ(n4.toString(), "8'd764");
+  EXPECT_EQ(n4.toString(), "8'764");
 
   vAST::NumericLiteral n5("764", 8);
-  EXPECT_EQ(n5.toString(), "8'd764");
+  EXPECT_EQ(n5.toString(), "8'764");
 
   vAST::NumericLiteral n6("764");
-  EXPECT_EQ(n6.toString(), "32'd764");
+  EXPECT_EQ(n6.toString(), "764");
 
   vAST::NumericLiteral n7("764", 8, true);
-  EXPECT_EQ(n7.toString(), "8'sd764");
+  EXPECT_EQ(n7.toString(), "8's764");
 }
 
 TEST(BasicTests, TestIdentifier) {
@@ -45,7 +45,7 @@ TEST(BasicTests, TestIndex) {
   vAST::Identifier id("x");
   vAST::NumericLiteral n("0");
   vAST::Index index(&id, &n);
-  EXPECT_EQ(index.toString(), "x[32'd0]");
+  EXPECT_EQ(index.toString(), "x[0]");
 }
 
 TEST(BasicTests, TestSlice) {
@@ -53,7 +53,7 @@ TEST(BasicTests, TestSlice) {
   vAST::NumericLiteral high("31");
   vAST::NumericLiteral low("0");
   vAST::Slice slice(&id, &high, &low);
-  EXPECT_EQ(slice.toString(), "x[32'd31:32'd0]");
+  EXPECT_EQ(slice.toString(), "x[31:0]");
 }
 
 TEST(BasicTests, TestVector) {
@@ -61,7 +61,7 @@ TEST(BasicTests, TestVector) {
   vAST::NumericLiteral high("31");
   vAST::NumericLiteral low("0");
   vAST::Vector slice(&id, &high, &low);
-  EXPECT_EQ(slice.toString(), "[32'd31:32'd0] x");
+  EXPECT_EQ(slice.toString(), "[31:0] x");
 }
 
 TEST(BasicTests, TestBinaryOp) {
@@ -118,7 +118,7 @@ TEST(BasicTests, TestTernaryOp) {
   vAST::NumericLiteral zero("0");
   vAST::NumericLiteral one("1");
   vAST::TernaryOp tern_op(&un_op, &one, &zero);
-  EXPECT_EQ(tern_op.toString(), "~ x ? 32'd1 : 32'd0");
+  EXPECT_EQ(tern_op.toString(), "~ x ? 1 : 0");
 }
 
 TEST(BasicTests, TestNegEdge) {
@@ -190,8 +190,8 @@ TEST(BasicTests, TestModuleInst) {
                                         connections);
 
   EXPECT_EQ(module_inst.toString(),
-            "test_module #(.param0(32'd0), .param1(32'd1)) "
-            "test_module_inst(.a(a), .b(b[32'd0]), .c(c[32'd31:32'd0]));");
+            "test_module #(.param0(0), .param1(1)) "
+            "test_module_inst(.a(a), .b(b[0]), .c(c[31:0]));");
 }
 
 TEST(BasicTests, TestModule) {
@@ -238,26 +238,27 @@ TEST(BasicTests, TestModule) {
   vAST::Module module(name, ports, body, parameters);
 
   std::string expected_str =
-      "module test_module (input i, output o);\nother_module #(.param0(32'd0), "
-      ".param1(32'd1)) other_module_inst(.a(a), .b(b[32'd0]), "
-      ".c(c[32'd31:32'd0]));\nendmodule\n";
+      "module test_module (input i, output o);\nother_module #(.param0(0), "
+      ".param1(1)) other_module_inst(.a(a), .b(b[0]), "
+      ".c(c[31:0]));\nendmodule\n";
   EXPECT_EQ(module.toString(), expected_str);
 
   parameters = {{&param0, &zero}, {&param1, &one}};
   vAST::Module module_with_params(name, ports, body, parameters);
 
   expected_str =
-      "module test_module #(parameter param0 = 32'd0, parameter param1 = "
-      "32'd1) (input i, output o);\nother_module #(.param0(32'd0), "
-      ".param1(32'd1)) other_module_inst(.a(a), .b(b[32'd0]), "
-      ".c(c[32'd31:32'd0]));\nendmodule\n";
+      "module test_module #(parameter param0 = 0, parameter param1 = "
+      "1) (input i, output o);\nother_module #(.param0(0), "
+      ".param1(1)) other_module_inst(.a(a), .b(b[0]), "
+      ".c(c[31:0]));\nendmodule\n";
   EXPECT_EQ(module_with_params.toString(), expected_str);
 
   std::string string_body = "reg d;\nassign d = a + b;\nassign c = d;";
-  vAST::StringBodyModule string_body_module(name, ports, string_body, parameters);
+  vAST::StringBodyModule string_body_module(name, ports, string_body,
+                                            parameters);
   expected_str =
-      "module test_module #(parameter param0 = 32'd0, parameter param1 = "
-      "32'd1) (input i, output o);\nreg d;\nassign d = a + b;\nassign c = "
+      "module test_module #(parameter param0 = 0, parameter param1 = "
+      "1) (input i, output o);\nreg d;\nassign d = a + b;\nassign c = "
       "d;\nendmodule\n";
   EXPECT_EQ(string_body_module.toString(), expected_str);
 
@@ -278,7 +279,7 @@ TEST(BasicTests, TestDeclaration) {
   vAST::NumericLiteral low("0");
   vAST::Vector slice(&id, &high, &low);
   vAST::Reg reg_slice(&slice);
-  EXPECT_EQ(reg_slice.toString(), "reg [32'd31:32'd0] x;");
+  EXPECT_EQ(reg_slice.toString(), "reg [31:0] x;");
 }
 
 TEST(BasicTests, TestAssign) {
@@ -385,21 +386,21 @@ TEST(BasicTests, File) {
 
   std::string expected_str =
       "module test_module0 (input i, output o);\nother_module "
-      "#(.param0(32'd0), .param1(32'd1)) other_module_inst(.a(a), "
-      ".b(b[32'd0]), .c(c[32'd31:32'd0]));\nendmodule\n\n"
-      "module test_module1 #(parameter param0 = 32'd0, parameter param1 = "
-      "32'd1) (input i, output o);\nother_module #(.param0(32'd0), "
-      ".param1(32'd1)) other_module_inst(.a(a), .b(b[32'd0]), "
-      ".c(c[32'd31:32'd0]));\nendmodule\n";
+      "#(.param0(0), .param1(1)) other_module_inst(.a(a), "
+      ".b(b[0]), .c(c[31:0]));\nendmodule\n\n"
+      "module test_module1 #(parameter param0 = 0, parameter param1 = "
+      "1) (input i, output o);\nother_module #(.param0(0), "
+      ".param1(1)) other_module_inst(.a(a), .b(b[0]), "
+      ".c(c[31:0]));\nendmodule\n";
   EXPECT_EQ(file.toString(), expected_str);
 }
 TEST(BasicTests, Comment) {
-    vAST::SingleLineComment single_line_comment("Test comment");
-    EXPECT_EQ(single_line_comment.toString(), "// Test comment");
-    vAST::BlockComment block_comment("Test comment\non multiple lines");
-    EXPECT_EQ(block_comment.toString(), "/*\nTest comment\non multiple lines\n*/");
+  vAST::SingleLineComment single_line_comment("Test comment");
+  EXPECT_EQ(single_line_comment.toString(), "// Test comment");
+  vAST::BlockComment block_comment("Test comment\non multiple lines");
+  EXPECT_EQ(block_comment.toString(),
+            "/*\nTest comment\non multiple lines\n*/");
 }
-    
 
 }  // namespace
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -56,6 +56,14 @@ TEST(BasicTests, TestSlice) {
   EXPECT_EQ(slice.toString(), "x[32'd31:32'd0]");
 }
 
+TEST(BasicTests, TestVector) {
+  vAST::Identifier id("x");
+  vAST::NumericLiteral high("31");
+  vAST::NumericLiteral low("0");
+  vAST::Vector slice(&id, &high, &low);
+  EXPECT_EQ(slice.toString(), "[32'd31:32'd0] x");
+}
+
 TEST(BasicTests, TestBinaryOp) {
   std::vector<std::pair<vAST::BinOp::BinOp, std::string>> ops;
   ops.push_back(std::make_pair(vAST::BinOp::LSHIFT, "<<"));
@@ -266,16 +274,11 @@ TEST(BasicTests, TestDeclaration) {
   EXPECT_EQ(reg.toString(), "reg a;");
 
   vAST::Identifier id("x");
-  vAST::NumericLiteral n("0");
-  vAST::Index index(&id, &n);
-  vAST::Wire wire_index(&index);
-  EXPECT_EQ(wire_index.toString(), "wire x[32'd0];");
-
   vAST::NumericLiteral high("31");
   vAST::NumericLiteral low("0");
-  vAST::Slice slice(&id, &high, &low);
+  vAST::Vector slice(&id, &high, &low);
   vAST::Reg reg_slice(&slice);
-  EXPECT_EQ(reg_slice.toString(), "reg x[32'd31:32'd0];");
+  EXPECT_EQ(reg_slice.toString(), "reg [32'd31:32'd0] x;");
 }
 
 TEST(BasicTests, TestAssign) {

--- a/tests/parameterized_module.cpp
+++ b/tests/parameterized_module.cpp
@@ -52,7 +52,7 @@ TEST(ParameterizedModuleTests, TestEq) {
 
   cout << "//coreir_eq" << endl << coreir_eq.toString() << endl;
   std::string expected_str =
-      "module coreir_eq #(parameter width = 32'd1) (input [width - 32'd1:32'd0] in0, input [width - 32'd1:32'd0] in1, output out);\n"
+      "module coreir_eq #(parameter width = 1) (input [width - 1:0] in0, input [width - 1:0] in1, output out);\n"
       "assign out = in0 == in1;\n"
       "endmodule\n";
   EXPECT_EQ(coreir_eq.toString(), expected_str);

--- a/tests/parameterized_module.cpp
+++ b/tests/parameterized_module.cpp
@@ -30,11 +30,11 @@ TEST(ParameterizedModuleTests, TestEq) {
   vAST::BinaryOp hi(&width,vAST::BinOp::SUB,&one);
   auto lo = zero;
 
-  vAST::Slice in0_slice(&in0, &hi, &lo);
-  vAST::Slice in1_slice(&in1, &hi, &lo);
+  vAST::Vector in0_vec(&in0, &hi, &lo);
+  vAST::Vector in1_vec(&in1, &hi, &lo);
 
-  vAST::Port in0_port(&in0_slice, vAST::INPUT, vAST::WIRE);
-  vAST::Port in1_port(&in1_slice, vAST::INPUT, vAST::WIRE);
+  vAST::Port in0_port(&in0_vec, vAST::INPUT, vAST::WIRE);
+  vAST::Port in1_port(&in1_vec, vAST::INPUT, vAST::WIRE);
   vAST::Port out_port(&out, vAST::OUTPUT, vAST::WIRE);
 
   std::vector<vAST::AbstractPort *> ports = {&in0_port, &in1_port, &out_port};
@@ -52,7 +52,7 @@ TEST(ParameterizedModuleTests, TestEq) {
 
   cout << "//coreir_eq" << endl << coreir_eq.toString() << endl;
   std::string expected_str =
-      "module coreir_eq #(parameter width = 32'd1) (input in0[width - 32'd1:32'd0], input in1[width - 32'd1:32'd0], output out);\n"
+      "module coreir_eq #(parameter width = 32'd1) (input [width - 32'd1:32'd0] in0, input [width - 32'd1:32'd0] in1, output out);\n"
       "assign out = in0 == in1;\n"
       "endmodule\n";
   EXPECT_EQ(coreir_eq.toString(), expected_str);


### PR DESCRIPTION
These use different syntax (square brace contents come before the
identifier).

Fixes https://github.com/leonardt/verilogAST-cpp/issues/11