### PR TITLE
Unique ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=c++17")
 
 option(VERILOGAST_BUILD_TESTS "Build all of verilogAST's own tests." OFF)
 

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -522,32 +522,21 @@ class File : public Node {
 };
 
 // Helper functions for constructing unique pointers
-std::unique_ptr<Identifier> make_id(std::string name) {
-  return std::make_unique<Identifier>(name);
-}
+std::unique_ptr<Identifier> make_id(std::string name);
 
-std::unique_ptr<NumericLiteral> make_num(std::string val) {
-  return std::make_unique<NumericLiteral>(val);
-}
+std::unique_ptr<NumericLiteral> make_num(std::string val);
 
 std::unique_ptr<BinaryOp> make_binop(std::unique_ptr<Expression> left,
                                      BinOp::BinOp op,
-                                     std::unique_ptr<Expression> right) {
-  return std::make_unique<BinaryOp>(std::move(left), op, std::move(right));
-}
+                                     std::unique_ptr<Expression> right);
 
 std::unique_ptr<Port> make_port(
     std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Vector>> value,
-    Direction direction, PortType data_type) {
-  return std::make_unique<Port>(std::move(value), direction, data_type);
-}
+    Direction direction, PortType data_type);
 
 std::unique_ptr<Vector> make_vector(std::unique_ptr<Identifier> id,
                                     std::unique_ptr<Expression> msb,
-                                    std::unique_ptr<Expression> lsb) {
-  return std::make_unique<Vector>(std::move(id), std::move(msb),
-                                  std::move(lsb));
-}
+                                    std::unique_ptr<Expression> lsb);
 
 }  // namespace verilogAST
 #endif

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -179,6 +179,15 @@ class TernaryOp : public Expression {
   ~TernaryOp(){};
 };
 
+class Concat : public Expression {
+  std::vector<std::unique_ptr<Expression>> args;
+
+ public:
+  Concat(std::vector<std::unique_ptr<Expression>> args)
+      : args(std::move(args)){};
+  std::string toString();
+};
+
 class NegEdge : public Expression {
   std::unique_ptr<Expression> value;
 

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -269,9 +269,9 @@ class ModuleInstantiation : public StructuralStatement {
 class Declaration : public Node {
  protected:
   std::string decl;
-  std::variant<Identifier *, Vector *> value;
+  std::variant<Identifier *, Index *, Slice *, Vector *> value;
 
-  Declaration(std::variant<Identifier *, Vector *> value,
+  Declaration(std::variant<Identifier *, Index *, Slice *, Vector *> value,
               std::string decl)
       : decl(decl), value(value){};
 
@@ -281,13 +281,13 @@ class Declaration : public Node {
 
 class Wire : public Declaration {
  public:
-  Wire(std::variant<Identifier *, Vector *> value)
+  Wire(std::variant<Identifier *, Index *, Slice *, Vector *> value)
       : Declaration(value, "wire"){};
 };
 
 class Reg : public Declaration {
  public:
-  Reg(std::variant<Identifier *, Vector *> value)
+  Reg(std::variant<Identifier *, Index *, Slice *, Vector *> value)
       : Declaration(value, "reg"){};
 };
 

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -9,11 +9,13 @@ namespace verilogAST {
 class Node {
  public:
   virtual std::string toString() = 0;
+  virtual ~Node() = default;
 };
 
 class Expression : public Node {
  public:
   virtual std::string toString() = 0;
+  virtual ~Expression() = default;
 };
 
 enum Radix { BINARY, OCTAL, HEX, DECIMAL };
@@ -56,6 +58,7 @@ class Identifier : public Expression {
   Identifier(std::string value) : value(value){};
 
   std::string toString() override;
+  ~Identifier() {};
 };
 
 class String : public Expression {
@@ -65,26 +68,30 @@ class String : public Expression {
   String(std::string value) : value(value){};
 
   std::string toString() override;
+  ~String() {};
 };
 
 class Index : public Expression {
-  Identifier *id;
-  Expression *index;
+  std::unique_ptr<Identifier> id;
+  std::unique_ptr<Expression> index;
 
  public:
-  Index(Identifier *id, Expression *index) : id(id), index(index){};
+  Index(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> index) : id(std::move(id)), index(std::move(index)){};
   std::string toString() override;
+  ~Index() {};
 };
 
 class Slice : public Expression {
-  Identifier *id;
-  Expression *high_index;
-  Expression *low_index;
+  std::unique_ptr<Identifier> id;
+  std::unique_ptr<Expression> high_index;
+  std::unique_ptr<Expression> low_index;
 
  public:
-  Slice(Identifier *id, Expression *high_index, Expression *low_index)
-      : id(id), high_index(high_index), low_index(low_index){};
+  Slice(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> high_index,
+        std::unique_ptr<Expression> low_index)
+      : id(std::move(id)), high_index(std::move(high_index)), low_index(std::move(low_index)){};
   std::string toString() override;
+  ~Slice() {};
 };
 
 namespace BinOp {
@@ -108,14 +115,15 @@ enum BinOp {
 }
 
 class BinaryOp : public Expression {
-  Expression *left;
+    std::unique_ptr<Expression> left;
   BinOp::BinOp op;
-  Expression *right;
+  std::unique_ptr<Expression> right;
 
  public:
-  BinaryOp(Expression *left, BinOp::BinOp op, Expression *right)
-      : left(left), op(op), right(right){};
+  BinaryOp(std::unique_ptr<Expression> left, BinOp::BinOp op, std::unique_ptr<Expression> right)
+      : left(std::move(left)), op(op), right(std::move(right)){};
   std::string toString() override;
+  ~BinaryOp() {};
 };
 
 namespace UnOp {
@@ -135,40 +143,44 @@ enum UnOp {
 }
 
 class UnaryOp : public Expression {
-  Expression *operand;
+  std::unique_ptr<Expression> operand;
 
   UnOp::UnOp op;
 
  public:
-  UnaryOp(Expression *operand, UnOp::UnOp op) : operand(operand), op(op){};
+  UnaryOp(std::unique_ptr<Expression> operand, UnOp::UnOp op) : operand(std::move(operand)), op(op){};
   std::string toString();
+  ~UnaryOp() {};
 };
 
 class TernaryOp : public Expression {
-  Expression *cond;
-  Expression *true_value;
-  Expression *false_value;
+    std::unique_ptr<Expression> cond;
+    std::unique_ptr<Expression> true_value;
+    std::unique_ptr<Expression> false_value;
 
  public:
-  TernaryOp(Expression *cond, Expression *true_value, Expression *false_value)
-      : cond(cond), true_value(true_value), false_value(false_value){};
+  TernaryOp(std::unique_ptr<Expression> cond, std::unique_ptr<Expression> true_value, std::unique_ptr<Expression> false_value)
+      : cond(std::move(cond)), true_value(std::move(true_value)), false_value(std::move(false_value)){};
   std::string toString();
+  ~TernaryOp() {};
 };
 
 class NegEdge : public Expression {
-  Expression *value;
+    std::unique_ptr<Expression> value;
 
  public:
-  NegEdge(Expression *value) : value(value){};
+  NegEdge(std::unique_ptr<Expression> value) : value(std::move(value)){};
   std::string toString();
+  ~NegEdge() {};
 };
 
 class PosEdge : public Expression {
-  Expression *value;
+    std::unique_ptr<Expression> value;
 
  public:
-  PosEdge(Expression *value) : value(value){};
+  PosEdge(std::unique_ptr<Expression> value) : value(std::move(value)){};
   std::string toString();
+  ~PosEdge() {};
 };
 
 enum Direction { INPUT, OUTPUT, INOUT };
@@ -179,20 +191,21 @@ enum PortType { WIRE, REG };
 class AbstractPort : public Node {};
 
 class Vector : public Node {
-  Identifier *id;
-  Expression *msb;
-  Expression *lsb;
+    std::unique_ptr<Identifier> id;
+    std::unique_ptr<Expression> msb;
+    std::unique_ptr<Expression> lsb;
 
  public:
-  Vector(Identifier *id, Expression *msb, Expression *lsb)
-      : id(id), msb(msb), lsb(lsb){};
+  Vector(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> msb, std::unique_ptr<Expression> lsb)
+      : id(std::move(id)), msb(std::move(msb)), lsb(std::move(lsb)){};
   std::string toString() override;
+  ~Vector() {};
 };
 
 class Port : public AbstractPort {
   // Required
   // `<name>` or `<name>[n]` or `name[n:m]`
-  std::variant<Identifier *, Vector *> value;
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Vector>> value;
 
   // technically the following are optional (e.g. port direction/data type
   // can be declared in the body of the definition), but for now let's force
@@ -202,10 +215,11 @@ class Port : public AbstractPort {
   PortType data_type;
 
  public:
-  Port(std::variant<Identifier *, Vector *> value, Direction direction,
+  Port(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Vector>> value, Direction direction,
        PortType data_type)
-      : value(value), direction(direction), data_type(data_type){};
+      : value(std::move(value)), direction(std::move(direction)), data_type(std::move(data_type)){};
   std::string toString();
+  ~Port() {};
 };
 
 class StringPort : public AbstractPort {
@@ -214,6 +228,7 @@ class StringPort : public AbstractPort {
  public:
   StringPort(std::string value) : value(value){};
   std::string toString() { return value; };
+  ~StringPort() {};
 };
 
 class Statement : public Node {};
@@ -224,6 +239,7 @@ class SingleLineComment : public Statement {
  public:
   SingleLineComment(std::string value) : value(value){};
   std::string toString() { return "// " + value; };
+  ~SingleLineComment() {};
 };
 
 class BlockComment : public Statement {
@@ -232,12 +248,13 @@ class BlockComment : public Statement {
  public:
   BlockComment(std::string value) : value(value){};
   std::string toString() { return "/*\n" + value + "\n*/"; };
+  ~BlockComment() {};
 };
 
 class BehavioralStatement : public Statement {};
 class StructuralStatement : public Statement {};
 
-typedef std::vector<std::pair<Identifier *, Expression *>> Parameters;
+typedef std::vector<std::pair<std::unique_ptr<Identifier>, std::unique_ptr<Expression>>> Parameters;
 
 class ModuleInstantiation : public StructuralStatement {
   std::string module_name;
@@ -249,7 +266,7 @@ class ModuleInstantiation : public StructuralStatement {
 
   // map from instance port names to connection expression
   // NOTE: anonymous style of module connections is not supported
-  std::map<std::string, std::variant<Identifier *, Index *, Slice *>>
+  std::map<std::string, std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>>>
       connections;
 
  public:
@@ -257,108 +274,117 @@ class ModuleInstantiation : public StructuralStatement {
   // module parameters
   ModuleInstantiation(
       std::string module_name, Parameters parameters, std::string instance_name,
-      std::map<std::string, std::variant<Identifier *, Index *, Slice *>>
+      std::map<std::string, std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>>>
           connections)
       : module_name(module_name),
-        parameters(parameters),
+        parameters(std::move(parameters)),
         instance_name(instance_name),
-        connections(connections){};
+        connections(std::move(connections)){};
   std::string toString();
+  ~ModuleInstantiation() {};
 };
 
 class Declaration : public Node {
  protected:
   std::string decl;
-  std::variant<Identifier *, Index *, Slice *, Vector *> value;
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value;
 
-  Declaration(std::variant<Identifier *, Index *, Slice *, Vector *> value,
-              std::string decl)
-      : decl(decl), value(value){};
+  Declaration(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value, std::string decl)
+      : decl(decl), value(std::move(value)){};
 
  public:
   std::string toString();
+  virtual ~Declaration() = default;
 };
 
 class Wire : public Declaration {
  public:
-  Wire(std::variant<Identifier *, Index *, Slice *, Vector *> value)
-      : Declaration(value, "wire"){};
+  Wire(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value)
+      : Declaration(std::move(value), "wire"){};
+  ~Wire() {};
 };
 
 class Reg : public Declaration {
  public:
-  Reg(std::variant<Identifier *, Index *, Slice *, Vector *> value)
-      : Declaration(value, "reg"){};
+  Reg(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value) : Declaration(std::move(value), "reg"){};
+  ~Reg() {};
 };
 
 class Assign : public Node {
  protected:
-  std::variant<Identifier *, Index *, Slice *> target;
-  Expression *value;
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target;
+  std::unique_ptr<Expression> value;
   std::string prefix;
   std::string symbol;
 
-  Assign(std::variant<Identifier *, Index *, Slice *> target, Expression *value,
+  Assign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target, std::unique_ptr<Expression> value,
          std::string prefix)
-      : target(target), value(value), prefix(prefix), symbol("="){};
-  Assign(std::variant<Identifier *, Index *, Slice *> target, Expression *value,
+      : target(std::move(target)), value(std::move(value)), prefix(prefix), symbol("="){};
+  Assign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target, std::unique_ptr<Expression> value,
          std::string prefix, std::string symbol)
-      : target(target), value(value), prefix(prefix), symbol(symbol){};
+      : target(std::move(target)), value(std::move(value)), prefix(prefix), symbol(symbol){};
 
  public:
   std::string toString();
+  virtual ~Assign() = default;
 };
 
 class ContinuousAssign : public StructuralStatement, public Assign {
  public:
-  ContinuousAssign(std::variant<Identifier *, Index *, Slice *> target,
-                   Expression *value)
-      : Assign(target, value, "assign "){};
+  ContinuousAssign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target,
+                   std::unique_ptr<Expression> value)
+      : Assign(std::move(target), std::move(value), "assign "){};
   // Multiple inheritance forces us to have to explicitly state this?
   std::string toString() { return Assign::toString(); };
+  ~ContinuousAssign() {};
 };
 
 class BehavioralAssign : public BehavioralStatement {};
 
 class BlockingAssign : public BehavioralAssign, public Assign {
  public:
-  BlockingAssign(std::variant<Identifier *, Index *, Slice *> target,
-                 Expression *value)
-      : Assign(target, value, ""){};
+  BlockingAssign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target,
+                   std::unique_ptr<Expression> value)
+      : Assign(std::move(target), std::move(value), ""){};
   // Multiple inheritance forces us to have to explicitly state this?
   std::string toString() { return Assign::toString(); };
+  ~BlockingAssign() {};
 };
 
 class NonBlockingAssign : public BehavioralAssign, public Assign {
  public:
-  NonBlockingAssign(std::variant<Identifier *, Index *, Slice *> target,
-                    Expression *value)
-      : Assign(target, value, "", "<="){};
+  NonBlockingAssign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target,
+                   std::unique_ptr<Expression> value)
+      : Assign(std::move(target), std::move(value), "", "<="){};
   // Multiple inheritance forces us to have to explicitly state this?
   std::string toString() { return Assign::toString(); };
+  ~NonBlockingAssign() {};
 };
 
 class Star : Node {
  public:
   std::string toString() { return "*"; };
+  ~Star() {};
 };
 
 class Always : public StructuralStatement {
-  std::vector<std::variant<Identifier *, PosEdge *, NegEdge *, Star *>>
+  std::vector<std::variant<std::unique_ptr<Identifier>, std::unique_ptr<PosEdge>, std::unique_ptr<NegEdge>, std::unique_ptr<Star>>>
       sensitivity_list;
-  std::vector<std::variant<BehavioralStatement *, Declaration *>> body;
+  std::vector<std::variant<std::unique_ptr<BehavioralStatement>, std::unique_ptr<Declaration>>> body;
 
  public:
-  Always(std::vector<std::variant<Identifier *, PosEdge *, NegEdge *, Star *>>
+  Always(std::vector<std::variant<std::unique_ptr<Identifier>, std::unique_ptr<PosEdge>, std::unique_ptr<NegEdge>, std::unique_ptr<Star>>>
              sensitivity_list,
-         std::vector<std::variant<BehavioralStatement *, Declaration *>> body)
-      : sensitivity_list(sensitivity_list), body(body) {
+         std::vector<std::variant<std::unique_ptr<BehavioralStatement>, std::unique_ptr<Declaration>>> body)
+      : body(std::move(body)) {
     if (sensitivity_list.empty()) {
       throw std::runtime_error(
           "vAST::Always expects non-empty sensitivity list");
     }
+    this->sensitivity_list = std::move(sensitivity_list);
   };
   std::string toString();
+  ~Always() {};
 };
 
 class AbstractModule : public Node {};
@@ -366,33 +392,35 @@ class AbstractModule : public Node {};
 class Module : public AbstractModule {
  protected:
   std::string name;
-  std::vector<AbstractPort *> ports;
-  std::vector<std::variant<StructuralStatement *, Declaration *>> body;
+  std::vector<std::unique_ptr<AbstractPort>> ports;
+  std::vector<std::variant<std::unique_ptr<StructuralStatement>, std::unique_ptr<Declaration>>> body;
   Parameters parameters;
   std::string emitModuleHeader();
   // Protected initializer that is used by the StringBodyModule subclass which
   // overrides the `body` field (but reuses the other fields)
-  Module(std::string name, std::vector<AbstractPort *> ports,
+  Module(std::string name, std::vector<std::unique_ptr<AbstractPort>> ports,
          Parameters parameters)
-      : name(name), ports(ports), parameters(parameters){};
+      : name(name), ports(std::move(ports)), parameters(std::move(parameters)){};
 
  public:
-  Module(std::string name, std::vector<AbstractPort *> ports,
-         std::vector<std::variant<StructuralStatement *, Declaration *>> body,
+  Module(std::string name, std::vector<std::unique_ptr<AbstractPort>> ports,
+         std::vector<std::variant<std::unique_ptr<StructuralStatement>, std::unique_ptr<Declaration>>> body,
          Parameters parameters)
-      : name(name), ports(ports), body(body), parameters(parameters){};
+      : name(name), ports(std::move(ports)), body(std::move(body)), parameters(std::move(parameters)){};
 
   std::string toString();
+  ~Module() {};
 };
 
 class StringBodyModule : public Module {
   std::string body;
 
  public:
-  StringBodyModule(std::string name, std::vector<AbstractPort *> ports,
+  StringBodyModule(std::string name, std::vector<std::unique_ptr<AbstractPort>> ports,
                    std::string body, Parameters parameters)
-      : Module(name, ports, parameters), body(body){};
+      : Module(name, std::move(ports), std::move(parameters)), body(body){};
   std::string toString();
+  ~StringBodyModule() {};
 };
 
 class StringModule : public AbstractModule {
@@ -401,14 +429,16 @@ class StringModule : public AbstractModule {
  public:
   StringModule(std::string definition) : definition(definition){};
   std::string toString() { return definition; };
+  ~StringModule() {};
 };
 
 class File : public Node {
-  std::vector<AbstractModule *> modules;
+  std::vector<std::unique_ptr<AbstractModule>> modules;
 
  public:
-  File(std::vector<AbstractModule *> modules) : modules(modules){};
+  File(std::vector<std::unique_ptr<AbstractModule>> &modules) : modules(std::move(modules)){};
   std::string toString();
+  ~File() {};
 };
 
 }  // namespace verilogAST

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -296,7 +296,7 @@ class ModuleInstantiation : public StructuralStatement {
   // NOTE: anonymous style of module connections is not supported
   std::map<std::string,
            std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
-                        std::unique_ptr<Slice>>>
+                        std::unique_ptr<Slice>, std::unique_ptr<Concat>>>
       connections;
 
  public:
@@ -306,7 +306,7 @@ class ModuleInstantiation : public StructuralStatement {
       std::string module_name, Parameters parameters, std::string instance_name,
       std::map<std::string,
                std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
-                            std::unique_ptr<Slice>>>
+                            std::unique_ptr<Slice>, std::unique_ptr<Concat>>>
           connections)
       : module_name(module_name),
         parameters(std::move(parameters)),

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -1,4 +1,7 @@
+#pragma once
+
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>  // std::pair
 #include <variant>
@@ -58,7 +61,7 @@ class Identifier : public Expression {
   Identifier(std::string value) : value(value){};
 
   std::string toString() override;
-  ~Identifier() {};
+  ~Identifier(){};
 };
 
 class String : public Expression {
@@ -68,7 +71,7 @@ class String : public Expression {
   String(std::string value) : value(value){};
 
   std::string toString() override;
-  ~String() {};
+  ~String(){};
 };
 
 class Index : public Expression {
@@ -76,9 +79,10 @@ class Index : public Expression {
   std::unique_ptr<Expression> index;
 
  public:
-  Index(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> index) : id(std::move(id)), index(std::move(index)){};
+  Index(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> index)
+      : id(std::move(id)), index(std::move(index)){};
   std::string toString() override;
-  ~Index() {};
+  ~Index(){};
 };
 
 class Slice : public Expression {
@@ -89,9 +93,11 @@ class Slice : public Expression {
  public:
   Slice(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> high_index,
         std::unique_ptr<Expression> low_index)
-      : id(std::move(id)), high_index(std::move(high_index)), low_index(std::move(low_index)){};
+      : id(std::move(id)),
+        high_index(std::move(high_index)),
+        low_index(std::move(low_index)){};
   std::string toString() override;
-  ~Slice() {};
+  ~Slice(){};
 };
 
 namespace BinOp {
@@ -115,15 +121,16 @@ enum BinOp {
 }
 
 class BinaryOp : public Expression {
-    std::unique_ptr<Expression> left;
+  std::unique_ptr<Expression> left;
   BinOp::BinOp op;
   std::unique_ptr<Expression> right;
 
  public:
-  BinaryOp(std::unique_ptr<Expression> left, BinOp::BinOp op, std::unique_ptr<Expression> right)
+  BinaryOp(std::unique_ptr<Expression> left, BinOp::BinOp op,
+           std::unique_ptr<Expression> right)
       : left(std::move(left)), op(op), right(std::move(right)){};
   std::string toString() override;
-  ~BinaryOp() {};
+  ~BinaryOp(){};
 };
 
 namespace UnOp {
@@ -148,39 +155,44 @@ class UnaryOp : public Expression {
   UnOp::UnOp op;
 
  public:
-  UnaryOp(std::unique_ptr<Expression> operand, UnOp::UnOp op) : operand(std::move(operand)), op(op){};
+  UnaryOp(std::unique_ptr<Expression> operand, UnOp::UnOp op)
+      : operand(std::move(operand)), op(op){};
   std::string toString();
-  ~UnaryOp() {};
+  ~UnaryOp(){};
 };
 
 class TernaryOp : public Expression {
-    std::unique_ptr<Expression> cond;
-    std::unique_ptr<Expression> true_value;
-    std::unique_ptr<Expression> false_value;
+  std::unique_ptr<Expression> cond;
+  std::unique_ptr<Expression> true_value;
+  std::unique_ptr<Expression> false_value;
 
  public:
-  TernaryOp(std::unique_ptr<Expression> cond, std::unique_ptr<Expression> true_value, std::unique_ptr<Expression> false_value)
-      : cond(std::move(cond)), true_value(std::move(true_value)), false_value(std::move(false_value)){};
+  TernaryOp(std::unique_ptr<Expression> cond,
+            std::unique_ptr<Expression> true_value,
+            std::unique_ptr<Expression> false_value)
+      : cond(std::move(cond)),
+        true_value(std::move(true_value)),
+        false_value(std::move(false_value)){};
   std::string toString();
-  ~TernaryOp() {};
+  ~TernaryOp(){};
 };
 
 class NegEdge : public Expression {
-    std::unique_ptr<Expression> value;
+  std::unique_ptr<Expression> value;
 
  public:
   NegEdge(std::unique_ptr<Expression> value) : value(std::move(value)){};
   std::string toString();
-  ~NegEdge() {};
+  ~NegEdge(){};
 };
 
 class PosEdge : public Expression {
-    std::unique_ptr<Expression> value;
+  std::unique_ptr<Expression> value;
 
  public:
   PosEdge(std::unique_ptr<Expression> value) : value(std::move(value)){};
   std::string toString();
-  ~PosEdge() {};
+  ~PosEdge(){};
 };
 
 enum Direction { INPUT, OUTPUT, INOUT };
@@ -191,15 +203,16 @@ enum PortType { WIRE, REG };
 class AbstractPort : public Node {};
 
 class Vector : public Node {
-    std::unique_ptr<Identifier> id;
-    std::unique_ptr<Expression> msb;
-    std::unique_ptr<Expression> lsb;
+  std::unique_ptr<Identifier> id;
+  std::unique_ptr<Expression> msb;
+  std::unique_ptr<Expression> lsb;
 
  public:
-  Vector(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> msb, std::unique_ptr<Expression> lsb)
+  Vector(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> msb,
+         std::unique_ptr<Expression> lsb)
       : id(std::move(id)), msb(std::move(msb)), lsb(std::move(lsb)){};
   std::string toString() override;
-  ~Vector() {};
+  ~Vector(){};
 };
 
 class Port : public AbstractPort {
@@ -215,11 +228,13 @@ class Port : public AbstractPort {
   PortType data_type;
 
  public:
-  Port(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Vector>> value, Direction direction,
-       PortType data_type)
-      : value(std::move(value)), direction(std::move(direction)), data_type(std::move(data_type)){};
+  Port(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Vector>> value,
+       Direction direction, PortType data_type)
+      : value(std::move(value)),
+        direction(std::move(direction)),
+        data_type(std::move(data_type)){};
   std::string toString();
-  ~Port() {};
+  ~Port(){};
 };
 
 class StringPort : public AbstractPort {
@@ -228,7 +243,7 @@ class StringPort : public AbstractPort {
  public:
   StringPort(std::string value) : value(value){};
   std::string toString() { return value; };
-  ~StringPort() {};
+  ~StringPort(){};
 };
 
 class Statement : public Node {};
@@ -239,7 +254,7 @@ class SingleLineComment : public Statement {
  public:
   SingleLineComment(std::string value) : value(value){};
   std::string toString() { return "// " + value; };
-  ~SingleLineComment() {};
+  ~SingleLineComment(){};
 };
 
 class BlockComment : public Statement {
@@ -248,13 +263,15 @@ class BlockComment : public Statement {
  public:
   BlockComment(std::string value) : value(value){};
   std::string toString() { return "/*\n" + value + "\n*/"; };
-  ~BlockComment() {};
+  ~BlockComment(){};
 };
 
 class BehavioralStatement : public Statement {};
 class StructuralStatement : public Statement {};
 
-typedef std::vector<std::pair<std::unique_ptr<Identifier>, std::unique_ptr<Expression>>> Parameters;
+typedef std::vector<
+    std::pair<std::unique_ptr<Identifier>, std::unique_ptr<Expression>>>
+    Parameters;
 
 class ModuleInstantiation : public StructuralStatement {
   std::string module_name;
@@ -266,7 +283,9 @@ class ModuleInstantiation : public StructuralStatement {
 
   // map from instance port names to connection expression
   // NOTE: anonymous style of module connections is not supported
-  std::map<std::string, std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>>>
+  std::map<std::string,
+           std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+                        std::unique_ptr<Slice>>>
       connections;
 
  public:
@@ -274,22 +293,29 @@ class ModuleInstantiation : public StructuralStatement {
   // module parameters
   ModuleInstantiation(
       std::string module_name, Parameters parameters, std::string instance_name,
-      std::map<std::string, std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>>>
+      std::map<std::string,
+               std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+                            std::unique_ptr<Slice>>>
           connections)
       : module_name(module_name),
         parameters(std::move(parameters)),
         instance_name(instance_name),
         connections(std::move(connections)){};
   std::string toString();
-  ~ModuleInstantiation() {};
+  ~ModuleInstantiation(){};
 };
 
 class Declaration : public Node {
  protected:
   std::string decl;
-  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value;
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+               std::unique_ptr<Slice>, std::unique_ptr<Vector>>
+      value;
 
-  Declaration(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value, std::string decl)
+  Declaration(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+                           std::unique_ptr<Slice>, std::unique_ptr<Vector>>
+                  value,
+              std::string decl)
       : decl(decl), value(std::move(value)){};
 
  public:
@@ -299,30 +325,48 @@ class Declaration : public Node {
 
 class Wire : public Declaration {
  public:
-  Wire(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value)
+  Wire(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+                    std::unique_ptr<Slice>, std::unique_ptr<Vector>>
+           value)
       : Declaration(std::move(value), "wire"){};
-  ~Wire() {};
+  ~Wire(){};
 };
 
 class Reg : public Declaration {
  public:
-  Reg(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>, std::unique_ptr<Vector>> value) : Declaration(std::move(value), "reg"){};
-  ~Reg() {};
+  Reg(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+                   std::unique_ptr<Slice>, std::unique_ptr<Vector>>
+          value)
+      : Declaration(std::move(value), "reg"){};
+  ~Reg(){};
 };
 
 class Assign : public Node {
  protected:
-  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target;
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+               std::unique_ptr<Slice>>
+      target;
   std::unique_ptr<Expression> value;
   std::string prefix;
   std::string symbol;
 
-  Assign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target, std::unique_ptr<Expression> value,
-         std::string prefix)
-      : target(std::move(target)), value(std::move(value)), prefix(prefix), symbol("="){};
-  Assign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target, std::unique_ptr<Expression> value,
-         std::string prefix, std::string symbol)
-      : target(std::move(target)), value(std::move(value)), prefix(prefix), symbol(symbol){};
+  Assign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+                      std::unique_ptr<Slice>>
+             target,
+         std::unique_ptr<Expression> value, std::string prefix)
+      : target(std::move(target)),
+        value(std::move(value)),
+        prefix(prefix),
+        symbol("="){};
+  Assign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>,
+                      std::unique_ptr<Slice>>
+             target,
+         std::unique_ptr<Expression> value, std::string prefix,
+         std::string symbol)
+      : target(std::move(target)),
+        value(std::move(value)),
+        prefix(prefix),
+        symbol(symbol){};
 
  public:
   std::string toString();
@@ -331,51 +375,65 @@ class Assign : public Node {
 
 class ContinuousAssign : public StructuralStatement, public Assign {
  public:
-  ContinuousAssign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target,
+  ContinuousAssign(std::variant<std::unique_ptr<Identifier>,
+                                std::unique_ptr<Index>, std::unique_ptr<Slice>>
+                       target,
                    std::unique_ptr<Expression> value)
       : Assign(std::move(target), std::move(value), "assign "){};
   // Multiple inheritance forces us to have to explicitly state this?
   std::string toString() { return Assign::toString(); };
-  ~ContinuousAssign() {};
+  ~ContinuousAssign(){};
 };
 
 class BehavioralAssign : public BehavioralStatement {};
 
 class BlockingAssign : public BehavioralAssign, public Assign {
  public:
-  BlockingAssign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target,
-                   std::unique_ptr<Expression> value)
+  BlockingAssign(std::variant<std::unique_ptr<Identifier>,
+                              std::unique_ptr<Index>, std::unique_ptr<Slice>>
+                     target,
+                 std::unique_ptr<Expression> value)
       : Assign(std::move(target), std::move(value), ""){};
   // Multiple inheritance forces us to have to explicitly state this?
   std::string toString() { return Assign::toString(); };
-  ~BlockingAssign() {};
+  ~BlockingAssign(){};
 };
 
 class NonBlockingAssign : public BehavioralAssign, public Assign {
  public:
-  NonBlockingAssign(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Index>, std::unique_ptr<Slice>> target,
-                   std::unique_ptr<Expression> value)
+  NonBlockingAssign(std::variant<std::unique_ptr<Identifier>,
+                                 std::unique_ptr<Index>, std::unique_ptr<Slice>>
+                        target,
+                    std::unique_ptr<Expression> value)
       : Assign(std::move(target), std::move(value), "", "<="){};
   // Multiple inheritance forces us to have to explicitly state this?
   std::string toString() { return Assign::toString(); };
-  ~NonBlockingAssign() {};
+  ~NonBlockingAssign(){};
 };
 
 class Star : Node {
  public:
   std::string toString() { return "*"; };
-  ~Star() {};
+  ~Star(){};
 };
 
 class Always : public StructuralStatement {
-  std::vector<std::variant<std::unique_ptr<Identifier>, std::unique_ptr<PosEdge>, std::unique_ptr<NegEdge>, std::unique_ptr<Star>>>
+  std::vector<
+      std::variant<std::unique_ptr<Identifier>, std::unique_ptr<PosEdge>,
+                   std::unique_ptr<NegEdge>, std::unique_ptr<Star>>>
       sensitivity_list;
-  std::vector<std::variant<std::unique_ptr<BehavioralStatement>, std::unique_ptr<Declaration>>> body;
+  std::vector<std::variant<std::unique_ptr<BehavioralStatement>,
+                           std::unique_ptr<Declaration>>>
+      body;
 
  public:
-  Always(std::vector<std::variant<std::unique_ptr<Identifier>, std::unique_ptr<PosEdge>, std::unique_ptr<NegEdge>, std::unique_ptr<Star>>>
+  Always(std::vector<
+             std::variant<std::unique_ptr<Identifier>, std::unique_ptr<PosEdge>,
+                          std::unique_ptr<NegEdge>, std::unique_ptr<Star>>>
              sensitivity_list,
-         std::vector<std::variant<std::unique_ptr<BehavioralStatement>, std::unique_ptr<Declaration>>> body)
+         std::vector<std::variant<std::unique_ptr<BehavioralStatement>,
+                                  std::unique_ptr<Declaration>>>
+             body)
       : body(std::move(body)) {
     if (sensitivity_list.empty()) {
       throw std::runtime_error(
@@ -384,7 +442,7 @@ class Always : public StructuralStatement {
     this->sensitivity_list = std::move(sensitivity_list);
   };
   std::string toString();
-  ~Always() {};
+  ~Always(){};
 };
 
 class AbstractModule : public Node {};
@@ -393,34 +451,44 @@ class Module : public AbstractModule {
  protected:
   std::string name;
   std::vector<std::unique_ptr<AbstractPort>> ports;
-  std::vector<std::variant<std::unique_ptr<StructuralStatement>, std::unique_ptr<Declaration>>> body;
+  std::vector<std::variant<std::unique_ptr<StructuralStatement>,
+                           std::unique_ptr<Declaration>>>
+      body;
   Parameters parameters;
   std::string emitModuleHeader();
   // Protected initializer that is used by the StringBodyModule subclass which
   // overrides the `body` field (but reuses the other fields)
   Module(std::string name, std::vector<std::unique_ptr<AbstractPort>> ports,
          Parameters parameters)
-      : name(name), ports(std::move(ports)), parameters(std::move(parameters)){};
+      : name(name),
+        ports(std::move(ports)),
+        parameters(std::move(parameters)){};
 
  public:
   Module(std::string name, std::vector<std::unique_ptr<AbstractPort>> ports,
-         std::vector<std::variant<std::unique_ptr<StructuralStatement>, std::unique_ptr<Declaration>>> body,
+         std::vector<std::variant<std::unique_ptr<StructuralStatement>,
+                                  std::unique_ptr<Declaration>>>
+             body,
          Parameters parameters)
-      : name(name), ports(std::move(ports)), body(std::move(body)), parameters(std::move(parameters)){};
+      : name(name),
+        ports(std::move(ports)),
+        body(std::move(body)),
+        parameters(std::move(parameters)){};
 
   std::string toString();
-  ~Module() {};
+  ~Module(){};
 };
 
 class StringBodyModule : public Module {
   std::string body;
 
  public:
-  StringBodyModule(std::string name, std::vector<std::unique_ptr<AbstractPort>> ports,
+  StringBodyModule(std::string name,
+                   std::vector<std::unique_ptr<AbstractPort>> ports,
                    std::string body, Parameters parameters)
       : Module(name, std::move(ports), std::move(parameters)), body(body){};
   std::string toString();
-  ~StringBodyModule() {};
+  ~StringBodyModule(){};
 };
 
 class StringModule : public AbstractModule {
@@ -429,16 +497,17 @@ class StringModule : public AbstractModule {
  public:
   StringModule(std::string definition) : definition(definition){};
   std::string toString() { return definition; };
-  ~StringModule() {};
+  ~StringModule(){};
 };
 
 class File : public Node {
   std::vector<std::unique_ptr<AbstractModule>> modules;
 
  public:
-  File(std::vector<std::unique_ptr<AbstractModule>> &modules) : modules(std::move(modules)){};
+  File(std::vector<std::unique_ptr<AbstractModule>> &modules)
+      : modules(std::move(modules)){};
   std::string toString();
-  ~File() {};
+  ~File(){};
 };
 
 }  // namespace verilogAST

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -510,4 +510,32 @@ class File : public Node {
   ~File(){};
 };
 
+// Helper functions for constructing unique pointers
+std::unique_ptr<Identifier> make_id(std::string name) {
+  return std::make_unique<Identifier>(name);
+}
+
+std::unique_ptr<NumericLiteral> make_num(std::string val) {
+  return std::make_unique<NumericLiteral>(val);
+}
+
+std::unique_ptr<BinaryOp> make_binop(std::unique_ptr<Expression> left,
+                                     BinOp::BinOp op,
+                                     std::unique_ptr<Expression> right) {
+  return std::make_unique<BinaryOp>(std::move(left), op, std::move(right));
+}
+
+std::unique_ptr<Port> make_port(
+    std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Vector>> value,
+    Direction direction, PortType data_type) {
+  return std::make_unique<Port>(std::move(value), direction, data_type);
+}
+
+std::unique_ptr<Vector> make_vector(std::unique_ptr<Identifier> id,
+                                    std::unique_ptr<Expression> msb,
+                                    std::unique_ptr<Expression> lsb) {
+  return std::make_unique<Vector>(std::move(id), std::move(msb),
+                                  std::move(lsb));
+}
+
 }  // namespace verilogAST

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef VERILOGAST_H
+#define VERILOGAST_H
 
 #include <map>
 #include <memory>
@@ -539,3 +541,4 @@ std::unique_ptr<Vector> make_vector(std::unique_ptr<Identifier> id,
 }
 
 }  // namespace verilogAST
+#endif

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -316,4 +316,31 @@ std::string File::toString() {
   return join(file_strs, "\n");
 }
 
+std::unique_ptr<Identifier> make_id(std::string name) {
+  return std::make_unique<Identifier>(name);
+}
+
+std::unique_ptr<NumericLiteral> make_num(std::string val) {
+  return std::make_unique<NumericLiteral>(val);
+}
+
+std::unique_ptr<BinaryOp> make_binop(std::unique_ptr<Expression> left,
+                                     BinOp::BinOp op,
+                                     std::unique_ptr<Expression> right) {
+  return std::make_unique<BinaryOp>(std::move(left), op, std::move(right));
+}
+
+std::unique_ptr<Port> make_port(
+    std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Vector>> value,
+    Direction direction, PortType data_type) {
+  return std::make_unique<Port>(std::move(value), direction, data_type);
+}
+
+std::unique_ptr<Vector> make_vector(std::unique_ptr<Identifier> id,
+                                    std::unique_ptr<Expression> msb,
+                                    std::unique_ptr<Expression> lsb) {
+  return std::make_unique<Vector>(std::move(id), std::move(msb),
+                                  std::move(lsb));
+}
+
 }  // namespace verilogAST

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -21,12 +21,12 @@ std::string NumericLiteral::toString() {
   }
   std::string size_str = std::to_string(size);
   if (size_str == "32") {
-      size_str = "";
+    size_str = "";
   }
 
   std::string separator = "";
   if (size_str + signed_str + radix_str != "") {
-      separator = "'";
+    separator = "'";
   }
   return size_str + separator + signed_str + radix_str + value;
 }
@@ -154,7 +154,8 @@ std::string variant_to_string(std::variant<Ts...> &value) {
 
 std::string Port::toString() {
   std::string value_str =
-      variant_to_string<std::unique_ptr<Identifier>, std::unique_ptr<Vector>>(value);
+      variant_to_string<std::unique_ptr<Identifier>, std::unique_ptr<Vector>>(
+          value);
   std::string direction_str;
   switch (direction) {
     case INPUT:
@@ -219,9 +220,9 @@ std::string Module::toString() {
 
   // emit body
   for (auto &statement : body) {
-    module_str +=
-        variant_to_string<std::unique_ptr<StructuralStatement>, std::unique_ptr<Declaration>>(statement) +
-        "\n";
+    module_str += variant_to_string<std::unique_ptr<StructuralStatement>,
+                                    std::unique_ptr<Declaration>>(statement) +
+                  "\n";
   }
 
   module_str += "endmodule\n";
@@ -285,9 +286,9 @@ std::string Always::toString() {
 
   // emit body
   for (auto &statement : body) {
-    always_str +=
-        variant_to_string<std::unique_ptr<BehavioralStatement>, std::unique_ptr<Declaration>>(statement) +
-        "\n";
+    always_str += variant_to_string<std::unique_ptr<BehavioralStatement>,
+                                    std::unique_ptr<Declaration>>(statement) +
+                  "\n";
   }
 
   always_str += "end\n";

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -1,5 +1,16 @@
 #include "verilogAST.hpp"
 
+// Helper function to join a vector of strings with a specified separator ala
+// Python's ",".join(...)
+std::string join(std::vector<std::string> vec, std::string separator) {
+  std::string result;
+  for (size_t i = 0; i < vec.size(); i++) {
+    if (i > 0) result += separator;
+    result += vec[i];
+  }
+  return result;
+}
+
 namespace verilogAST {
 std::string NumericLiteral::toString() {
   std::string signed_str = _signed ? "s" : "";
@@ -142,6 +153,14 @@ std::string TernaryOp::toString() {
          false_value->toString();
 }
 
+std::string Concat::toString() {
+  std::vector<std::string> arg_strs;
+  for (auto &arg : args) {
+    arg_strs.push_back(arg->toString());
+  }
+  return "{" + join(arg_strs, ",") + "}";
+}
+
 std::string NegEdge::toString() { return "negedge " + value->toString(); }
 
 std::string PosEdge::toString() { return "posedge " + value->toString(); }
@@ -179,15 +198,6 @@ std::string Port::toString() {
       break;
   }
   return direction_str + " " + data_type_str + value_str;
-}
-
-std::string join(std::vector<std::string> vec, std::string separator) {
-  std::string result;
-  for (size_t i = 0; i < vec.size(); i++) {
-    if (i > 0) result += separator;
-    result += vec[i];
-  }
-  return result;
 }
 
 std::string Module::emitModuleHeader() {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -43,18 +43,20 @@ TEST(BasicTests, TestString) {
 }
 
 TEST(BasicTests, TestIndex) {
-  vAST::Index index(make_id("x"), make_num("0"));
+  vAST::Index index(vAST::make_id("x"), vAST::make_num("0"));
   EXPECT_EQ(index.toString(), "x[0]");
 }
 
 TEST(BasicTests, TestSlice) {
   vAST::Identifier id("x");
-  vAST::Slice slice(make_id("x"), make_num("31"), make_num("0"));
+  vAST::Slice slice(vAST::make_id("x"), vAST::make_num("31"),
+                    vAST::make_num("0"));
   EXPECT_EQ(slice.toString(), "x[31:0]");
 }
 
 TEST(BasicTests, TestVector) {
-  vAST::Vector slice(make_id("x"), make_num("31"), make_num("0"));
+  vAST::Vector slice(vAST::make_id("x"), vAST::make_num("31"),
+                     vAST::make_num("0"));
   EXPECT_EQ(slice.toString(), "[31:0] x");
 }
 
@@ -77,7 +79,7 @@ TEST(BasicTests, TestBinaryOp) {
   for (auto it : ops) {
     vAST::BinOp::BinOp op = it.first;
     std::string op_str = it.second;
-    vAST::BinaryOp bin_op(make_id("x"), op, make_id("y"));
+    vAST::BinaryOp bin_op(vAST::make_id("x"), op, vAST::make_id("y"));
     EXPECT_EQ(bin_op.toString(), "x " + op_str + " y");
   }
 }
@@ -98,7 +100,7 @@ TEST(BasicTests, TestUnaryOp) {
   for (auto it : ops) {
     vAST::UnOp::UnOp op = it.first;
     std::string op_str = it.second;
-    vAST::UnaryOp un_op(make_id("x"), op);
+    vAST::UnaryOp un_op(vAST::make_id("x"), op);
     EXPECT_EQ(un_op.toString(), op_str + " x");
   }
 }
@@ -107,37 +109,37 @@ TEST(BasicTests, TestTernaryOp) {
   vAST::UnaryOp un_op(std::make_unique<vAST::Identifier>("x"),
                       vAST::UnOp::INVERT);
   vAST::TernaryOp tern_op(
-      std::make_unique<vAST::UnaryOp>(make_id("x"), vAST::UnOp::INVERT),
-      make_num("1"), make_num("0"));
+      std::make_unique<vAST::UnaryOp>(vAST::make_id("x"), vAST::UnOp::INVERT),
+      vAST::make_num("1"), vAST::make_num("0"));
   EXPECT_EQ(tern_op.toString(), "~ x ? 1 : 0");
 }
 
 TEST(BasicTests, TestNegEdge) {
-  vAST::NegEdge neg_edge(make_id("clk"));
+  vAST::NegEdge neg_edge(vAST::make_id("clk"));
 
   EXPECT_EQ(neg_edge.toString(), "negedge clk");
 }
 
 TEST(BasicTests, TestPosEdge) {
-  vAST::PosEdge pos_edge(make_id("clk"));
+  vAST::PosEdge pos_edge(vAST::make_id("clk"));
 
   EXPECT_EQ(pos_edge.toString(), "posedge clk");
 }
 
 TEST(BasicTests, TestPort) {
-  vAST::Port i_port(make_id("i"), vAST::INPUT, vAST::WIRE);
+  vAST::Port i_port(vAST::make_id("i"), vAST::INPUT, vAST::WIRE);
 
   EXPECT_EQ(i_port.toString(), "input i");
 
-  vAST::Port o_port(make_id("o"), vAST::OUTPUT, vAST::WIRE);
+  vAST::Port o_port(vAST::make_id("o"), vAST::OUTPUT, vAST::WIRE);
 
   EXPECT_EQ(o_port.toString(), "output o");
 
-  vAST::Port io_port(make_id("io"), vAST::INOUT, vAST::WIRE);
+  vAST::Port io_port(vAST::make_id("io"), vAST::INOUT, vAST::WIRE);
 
   EXPECT_EQ(io_port.toString(), "inout io");
 
-  vAST::Port o_reg_port(make_id("o"), vAST::OUTPUT, vAST::REG);
+  vAST::Port o_reg_port(vAST::make_id("o"), vAST::OUTPUT, vAST::REG);
 
   EXPECT_EQ(o_reg_port.toString(), "output reg o");
 }

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -260,16 +260,7 @@ TEST(BasicTests, TestAlways) {
       std::make_unique<vAST::PosEdge>(std::make_unique<vAST::Identifier>("b")));
   sensitivity_list.push_back(
       std::make_unique<vAST::NegEdge>(std::make_unique<vAST::Identifier>("c")));
-  std::vector<std::variant<std::unique_ptr<vAST::BehavioralStatement>,
-                           std::unique_ptr<vAST::Declaration>>>
-      body;
-  body.push_back(std::make_unique<vAST::BlockingAssign>(
-      std::make_unique<vAST::Identifier>("a"),
-      std::make_unique<vAST::Identifier>("b")));
-  body.push_back(std::make_unique<vAST::NonBlockingAssign>(
-      std::make_unique<vAST::Identifier>("b"),
-      std::make_unique<vAST::Identifier>("c")));
-  vAST::Always always(std::move(sensitivity_list), std::move(body));
+  vAST::Always always(std::move(sensitivity_list), make_simple_always_body());
   std::string expected_str =
       "always @(a, posedge b, negedge c) begin\n"
       "a = b;\n"
@@ -283,17 +274,9 @@ TEST(BasicTests, TestAlwaysStar) {
       std::unique_ptr<vAST::Identifier>, std::unique_ptr<vAST::PosEdge>,
       std::unique_ptr<vAST::NegEdge>, std::unique_ptr<vAST::Star>>>
       sensitivity_list;
-  std::vector<std::variant<std::unique_ptr<vAST::BehavioralStatement>,
-                           std::unique_ptr<vAST::Declaration>>>
-      body;
-  body.push_back(std::make_unique<vAST::BlockingAssign>(
-      std::make_unique<vAST::Identifier>("a"),
-      std::make_unique<vAST::Identifier>("b")));
-  body.push_back(std::make_unique<vAST::NonBlockingAssign>(
-      std::make_unique<vAST::Identifier>("b"),
-      std::make_unique<vAST::Identifier>("c")));
   sensitivity_list.push_back(std::make_unique<vAST::Star>());
-  vAST::Always always_star(std::move(sensitivity_list), std::move(body));
+  vAST::Always always_star(std::move(sensitivity_list),
+                           make_simple_always_body());
   std::string expected_str =
       "always @(*) begin\n"
       "a = b;\n"

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -277,9 +277,17 @@ TEST(BasicTests, TestDeclaration) {
   vAST::Identifier id("x");
   vAST::NumericLiteral high("31");
   vAST::NumericLiteral low("0");
-  vAST::Vector slice(&id, &high, &low);
+  vAST::Slice slice(&id, &high, &low);
   vAST::Reg reg_slice(&slice);
-  EXPECT_EQ(reg_slice.toString(), "reg [31:0] x;");
+  EXPECT_EQ(reg_slice.toString(), "reg x[31:0];");
+
+  vAST::Index index(&id, &high);
+  vAST::Reg reg_index(&index);
+  EXPECT_EQ(reg_index.toString(), "reg x[31];");
+
+  vAST::Vector vec(&id, &high, &low);
+  vAST::Reg reg_vec(&vec);
+  EXPECT_EQ(reg_vec.toString(), "reg [31:0] x;");
 }
 
 TEST(BasicTests, TestAssign) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -42,25 +42,23 @@ TEST(BasicTests, TestString) {
 }
 
 TEST(BasicTests, TestIndex) {
-  vAST::Identifier id("x");
-  vAST::NumericLiteral n("0");
-  vAST::Index index(&id, &n);
+  vAST::Index index(std::make_unique<vAST::Identifier>("x"),
+                    std::make_unique<vAST::NumericLiteral>("0"));
   EXPECT_EQ(index.toString(), "x[0]");
 }
 
 TEST(BasicTests, TestSlice) {
   vAST::Identifier id("x");
-  vAST::NumericLiteral high("31");
-  vAST::NumericLiteral low("0");
-  vAST::Slice slice(&id, &high, &low);
+  vAST::Slice slice(std::make_unique<vAST::Identifier>("x"),
+                    std::make_unique<vAST::NumericLiteral>("31"),
+                    std::make_unique<vAST::NumericLiteral>("0"));
   EXPECT_EQ(slice.toString(), "x[31:0]");
 }
 
 TEST(BasicTests, TestVector) {
-  vAST::Identifier id("x");
-  vAST::NumericLiteral high("31");
-  vAST::NumericLiteral low("0");
-  vAST::Vector slice(&id, &high, &low);
+  vAST::Vector slice(std::make_unique<vAST::Identifier>("x"),
+                     std::make_unique<vAST::NumericLiteral>("31"),
+                     std::make_unique<vAST::NumericLiteral>("0"));
   EXPECT_EQ(slice.toString(), "[31:0] x");
 }
 
@@ -80,12 +78,11 @@ TEST(BasicTests, TestBinaryOp) {
   ops.push_back(std::make_pair(vAST::BinOp::MOD, "%"));
   ops.push_back(std::make_pair(vAST::BinOp::ALSHIFT, "<<<"));
   ops.push_back(std::make_pair(vAST::BinOp::ARSHIFT, ">>>"));
-  vAST::Identifier x("x");
-  vAST::Identifier y("y");
   for (auto it : ops) {
     vAST::BinOp::BinOp op = it.first;
     std::string op_str = it.second;
-    vAST::BinaryOp bin_op(&x, op, &y);
+    vAST::BinaryOp bin_op(std::make_unique<vAST::Identifier>("x"), op,
+                          std::make_unique<vAST::Identifier>("y"));
     EXPECT_EQ(bin_op.toString(), "x " + op_str + " y");
   }
 }
@@ -103,56 +100,55 @@ TEST(BasicTests, TestUnaryOp) {
   ops.push_back(std::make_pair(vAST::UnOp::XNOR, "^~"));
   ops.push_back(std::make_pair(vAST::UnOp::PLUS, "+"));
   ops.push_back(std::make_pair(vAST::UnOp::MINUS, "-"));
-  vAST::Identifier x("x");
   for (auto it : ops) {
     vAST::UnOp::UnOp op = it.first;
     std::string op_str = it.second;
-    vAST::UnaryOp un_op(&x, op);
+    vAST::UnaryOp un_op(std::make_unique<vAST::Identifier>("x"), op);
     EXPECT_EQ(un_op.toString(), op_str + " x");
   }
 }
 
 TEST(BasicTests, TestTernaryOp) {
-  vAST::Identifier x("x");
-  vAST::UnaryOp un_op(&x, vAST::UnOp::INVERT);
-  vAST::NumericLiteral zero("0");
-  vAST::NumericLiteral one("1");
-  vAST::TernaryOp tern_op(&un_op, &one, &zero);
+  vAST::UnaryOp un_op(std::make_unique<vAST::Identifier>("x"),
+                      vAST::UnOp::INVERT);
+  vAST::TernaryOp tern_op(
+      std::make_unique<vAST::UnaryOp>(std::make_unique<vAST::Identifier>("x"),
+                                      vAST::UnOp::INVERT),
+      std::make_unique<vAST::NumericLiteral>("1"),
+      std::make_unique<vAST::NumericLiteral>("0"));
   EXPECT_EQ(tern_op.toString(), "~ x ? 1 : 0");
 }
 
 TEST(BasicTests, TestNegEdge) {
-  vAST::Identifier clk("clk");
-  vAST::NegEdge neg_edge(&clk);
+  vAST::NegEdge neg_edge(std::make_unique<vAST::Identifier>("clk"));
 
   EXPECT_EQ(neg_edge.toString(), "negedge clk");
 }
 
 TEST(BasicTests, TestPosEdge) {
-  vAST::Identifier clk("clk");
-  vAST::PosEdge pos_edge(&clk);
+  vAST::PosEdge pos_edge(std::make_unique<vAST::Identifier>("clk"));
 
   EXPECT_EQ(pos_edge.toString(), "posedge clk");
 }
 
 TEST(BasicTests, TestPort) {
-  vAST::Identifier i("i");
-  vAST::Port i_port(&i, vAST::INPUT, vAST::WIRE);
+  vAST::Port i_port(std::make_unique<vAST::Identifier>("i"), vAST::INPUT,
+                    vAST::WIRE);
 
   EXPECT_EQ(i_port.toString(), "input i");
 
-  vAST::Identifier o("o");
-  vAST::Port o_port(&o, vAST::OUTPUT, vAST::WIRE);
+  vAST::Port o_port(std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT,
+                    vAST::WIRE);
 
   EXPECT_EQ(o_port.toString(), "output o");
 
-  vAST::Identifier io("io");
-  vAST::Port io_port(&io, vAST::INOUT, vAST::WIRE);
+  vAST::Port io_port(std::make_unique<vAST::Identifier>("io"), vAST::INOUT,
+                     vAST::WIRE);
 
   EXPECT_EQ(io_port.toString(), "inout io");
 
-  vAST::Identifier o_reg("o");
-  vAST::Port o_reg_port(&o_reg, vAST::OUTPUT, vAST::REG);
+  vAST::Port o_reg_port(std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT,
+                        vAST::REG);
 
   EXPECT_EQ(o_reg_port.toString(), "output reg o");
 }
@@ -166,28 +162,37 @@ TEST(BasicTests, TestStringPort) {
 TEST(BasicTests, TestModuleInst) {
   std::string module_name = "test_module";
 
-  vAST::NumericLiteral zero("0");
-  vAST::NumericLiteral one("1");
-
-  vAST::Identifier param0("param0");
-  vAST::Identifier param1("param1");
-  vAST::Parameters parameters = {{&param0, &zero}, {&param1, &one}};
+  vAST::Parameters parameters;
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
 
   std::string instance_name = "test_module_inst";
   vAST::Identifier a("a");
-  vAST::Identifier b("b");
-  vAST::Index b_index(&b, &zero);
-  vAST::Identifier c("c");
-  vAST::NumericLiteral high("31");
-  vAST::NumericLiteral low("0");
-  vAST::Slice c_slice(&c, &high, &low);
+  vAST::Index b_index(std::make_unique<vAST::Identifier>("b"),
+                      std::make_unique<vAST::NumericLiteral>("0"));
+  vAST::Slice c_slice(std::make_unique<vAST::Identifier>("c"),
+                      std::make_unique<vAST::NumericLiteral>("31"),
+                      std::make_unique<vAST::NumericLiteral>("0"));
 
-  std::map<std::string,
-           std::variant<vAST::Identifier *, vAST::Index *, vAST::Slice *>>
-      connections = {{"a", &a}, {"b", &b_index}, {"c", &c_slice}};
+  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
+                                     std::unique_ptr<vAST::Index>,
+                                     std::unique_ptr<vAST::Slice>>>
+      connections;
+  connections["a"] = std::make_unique<vAST::Identifier>("a");
+  connections["b"] = std::make_unique<vAST::Index>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+  connections["c"] = std::make_unique<vAST::Slice>(
+      std::make_unique<vAST::Identifier>("c"),
+      std::make_unique<vAST::NumericLiteral>("31"),
+      std::make_unique<vAST::NumericLiteral>("0"));
 
-  vAST::ModuleInstantiation module_inst(module_name, parameters, instance_name,
-                                        connections);
+  vAST::ModuleInstantiation module_inst(module_name, std::move(parameters), instance_name,
+                                        std::move(connections));
 
   EXPECT_EQ(module_inst.toString(),
             "test_module #(.param0(0), .param1(1)) "
@@ -197,66 +202,150 @@ TEST(BasicTests, TestModuleInst) {
 TEST(BasicTests, TestModule) {
   std::string name = "test_module";
 
-  vAST::Identifier i("i");
-  vAST::Port i_port(&i, vAST::INPUT, vAST::WIRE);
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
 
-  vAST::Identifier o("o");
-  vAST::Port o_port(&o, vAST::OUTPUT, vAST::WIRE);
-
-  std::vector<vAST::AbstractPort *> ports = {&i_port, &o_port};
-
-  std::vector<std::variant<vAST::StructuralStatement *, vAST::Declaration *>>
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
       body;
 
   std::string module_name = "other_module";
 
-  vAST::NumericLiteral zero("0");
-  vAST::NumericLiteral one("1");
-  vAST::Identifier param0("param0");
-  vAST::Identifier param1("param1");
-
-  vAST::Parameters inst_parameters = {{&param0, &zero}, {&param1, &one}};
+  vAST::Parameters inst_parameters;
+  inst_parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  inst_parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
 
   std::string instance_name = "other_module_inst";
   vAST::Identifier a("a");
-  vAST::Identifier b("b");
-  vAST::Index b_index(&b, &zero);
-  vAST::Identifier c("c");
-  vAST::NumericLiteral high("31");
-  vAST::NumericLiteral low("0");
-  vAST::Slice c_slice(&c, &high, &low);
+  vAST::Index b_index(std::make_unique<vAST::Identifier>("b"),
+                      std::make_unique<vAST::NumericLiteral>("0"));
+  vAST::Slice c_slice(std::make_unique<vAST::Identifier>("c"),
+                      std::make_unique<vAST::NumericLiteral>("31"),
+                      std::make_unique<vAST::NumericLiteral>("0"));
 
-  std::map<std::string,
-           std::variant<vAST::Identifier *, vAST::Index *, vAST::Slice *>>
-      connections = {{"a", &a}, {"b", &b_index}, {"c", &c_slice}};
+  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
+                                     std::unique_ptr<vAST::Index>,
+                                     std::unique_ptr<vAST::Slice>>>
+      connections;
+  connections["a"] = std::make_unique<vAST::Identifier>("a");
+  connections["b"] = std::make_unique<vAST::Index>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+  connections["c"] = std::make_unique<vAST::Slice>(
+      std::make_unique<vAST::Identifier>("c"),
+      std::make_unique<vAST::NumericLiteral>("31"),
+      std::make_unique<vAST::NumericLiteral>("0"));
 
-  vAST::ModuleInstantiation module_inst(module_name, inst_parameters,
-                                        instance_name, connections);
-  body.push_back(&module_inst);
+  body.push_back(std::make_unique<vAST::ModuleInstantiation>(
+      module_name, std::move(inst_parameters), instance_name, std::move(connections)));
 
   vAST::Parameters parameters;
-  vAST::Module module(name, ports, body, parameters);
+  vAST::Module module(name, std::move(ports), std::move(body), std::move(parameters));
 
   std::string expected_str =
       "module test_module (input i, output o);\nother_module #(.param0(0), "
       ".param1(1)) other_module_inst(.a(a), .b(b[0]), "
       ".c(c[31:0]));\nendmodule\n";
   EXPECT_EQ(module.toString(), expected_str);
+}
 
-  parameters = {{&param0, &zero}, {&param1, &one}};
-  vAST::Module module_with_params(name, ports, body, parameters);
+TEST(BasicTests, TestParamModule) {
+  std::string name = "test_module";
 
-  expected_str =
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
+
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+
+  std::string module_name = "other_module";
+
+  vAST::Parameters inst_parameters;
+  inst_parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  inst_parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
+
+  std::string instance_name = "other_module_inst";
+  vAST::Identifier a("a");
+  vAST::Index b_index(std::make_unique<vAST::Identifier>("b"),
+                      std::make_unique<vAST::NumericLiteral>("0"));
+  vAST::Slice c_slice(std::make_unique<vAST::Identifier>("c"),
+                      std::make_unique<vAST::NumericLiteral>("31"),
+                      std::make_unique<vAST::NumericLiteral>("0"));
+
+  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
+                                     std::unique_ptr<vAST::Index>,
+                                     std::unique_ptr<vAST::Slice>>>
+      connections;
+  connections["a"] = std::make_unique<vAST::Identifier>("a");
+  connections["b"] = std::make_unique<vAST::Index>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+  connections["c"] = std::make_unique<vAST::Slice>(
+      std::make_unique<vAST::Identifier>("c"),
+      std::make_unique<vAST::NumericLiteral>("31"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+
+  body.push_back(std::make_unique<vAST::ModuleInstantiation>(
+      module_name, std::move(inst_parameters), instance_name, std::move(connections)));
+
+  vAST::Parameters parameters;
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
+  vAST::Module module_with_params(name, std::move(ports), std::move(body), std::move(parameters));
+
+  std::string expected_str =
       "module test_module #(parameter param0 = 0, parameter param1 = "
       "1) (input i, output o);\nother_module #(.param0(0), "
       ".param1(1)) other_module_inst(.a(a), .b(b[0]), "
       ".c(c[31:0]));\nendmodule\n";
   EXPECT_EQ(module_with_params.toString(), expected_str);
+}
+
+TEST(BasicTests, TestStringBodyModule) {
+  std::string name = "test_module";
+
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
+
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+  vAST::Parameters parameters;
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
+
+  std::string module_name = "other_module";
 
   std::string string_body = "reg d;\nassign d = a + b;\nassign c = d;";
-  vAST::StringBodyModule string_body_module(name, ports, string_body,
-                                            parameters);
-  expected_str =
+  vAST::StringBodyModule string_body_module(name, std::move(ports), string_body,
+                                            std::move(parameters));
+  std::string expected_str =
       "module test_module #(parameter param0 = 0, parameter param1 = "
       "1) (input i, output o);\nreg d;\nassign d = a + b;\nassign c = "
       "d;\nendmodule\n";
@@ -267,129 +356,208 @@ TEST(BasicTests, TestModule) {
 }
 
 TEST(BasicTests, TestDeclaration) {
-  vAST::Identifier a("a");
-  vAST::Wire wire(&a);
+  vAST::Wire wire(std::make_unique<vAST::Identifier>("a"));
   EXPECT_EQ(wire.toString(), "wire a;");
 
-  vAST::Reg reg(&a);
+  vAST::Reg reg(std::make_unique<vAST::Identifier>("a"));
   EXPECT_EQ(reg.toString(), "reg a;");
 
-  vAST::Identifier id("x");
-  vAST::NumericLiteral high("31");
-  vAST::NumericLiteral low("0");
-  vAST::Slice slice(&id, &high, &low);
-  vAST::Reg reg_slice(&slice);
+  vAST::Reg reg_slice(std::make_unique<vAST::Slice>(
+      std::make_unique<vAST::Identifier>("x"),
+      std::make_unique<vAST::NumericLiteral>("31"),
+      std::make_unique<vAST::NumericLiteral>("0")));
   EXPECT_EQ(reg_slice.toString(), "reg x[31:0];");
 
-  vAST::Index index(&id, &high);
-  vAST::Reg reg_index(&index);
+  vAST::Reg reg_index(std::make_unique<vAST::Index>(
+      std::make_unique<vAST::Identifier>("x"),
+      std::make_unique<vAST::NumericLiteral>("31")));
   EXPECT_EQ(reg_index.toString(), "reg x[31];");
 
-  vAST::Vector vec(&id, &high, &low);
-  vAST::Reg reg_vec(&vec);
+  vAST::Reg reg_vec(std::make_unique<vAST::Vector>(
+      std::make_unique<vAST::Identifier>("x"),
+      std::make_unique<vAST::NumericLiteral>("31"),
+      std::make_unique<vAST::NumericLiteral>("0")));
   EXPECT_EQ(reg_vec.toString(), "reg [31:0] x;");
 }
 
 TEST(BasicTests, TestAssign) {
-  vAST::Identifier a("a");
-  vAST::Identifier b("b");
-  vAST::ContinuousAssign cont_assign(&a, &b);
+  vAST::ContinuousAssign cont_assign(std::make_unique<vAST::Identifier>("a"),
+                                     std::make_unique<vAST::Identifier>("b"));
   EXPECT_EQ(cont_assign.toString(), "assign a = b;");
 
-  vAST::BlockingAssign blocking_assign(&a, &b);
+  vAST::BlockingAssign blocking_assign(std::make_unique<vAST::Identifier>("a"),
+                                       std::make_unique<vAST::Identifier>("b"));
   EXPECT_EQ(blocking_assign.toString(), "a = b;");
 
-  vAST::NonBlockingAssign non_blocking_assign(&a, &b);
+  vAST::NonBlockingAssign non_blocking_assign(
+      std::make_unique<vAST::Identifier>("a"),
+      std::make_unique<vAST::Identifier>("b"));
   EXPECT_EQ(non_blocking_assign.toString(), "a <= b;");
 }
 
 TEST(BasicTests, TestAlways) {
-  vAST::Identifier a("a");
-  vAST::Identifier b("b");
-  vAST::Identifier c("c");
-  std::vector<std::variant<vAST::Identifier *, vAST::PosEdge *, vAST::NegEdge *,
-                           vAST::Star *>>
+  std::vector<std::variant<
+      std::unique_ptr<vAST::Identifier>, std::unique_ptr<vAST::PosEdge>,
+      std::unique_ptr<vAST::NegEdge>, std::unique_ptr<vAST::Star>>>
       sensitivity_list;
-  sensitivity_list.push_back(&a);
-  vAST::PosEdge posedge(&b);
-  sensitivity_list.push_back(&posedge);
-  vAST::NegEdge negedge(&c);
-  sensitivity_list.push_back(&negedge);
-  std::vector<std::variant<vAST::BehavioralStatement *, vAST::Declaration *>>
+  sensitivity_list.push_back(std::make_unique<vAST::Identifier>("a"));
+  sensitivity_list.push_back(
+      std::make_unique<vAST::PosEdge>(std::make_unique<vAST::Identifier>("b")));
+  sensitivity_list.push_back(
+      std::make_unique<vAST::NegEdge>(std::make_unique<vAST::Identifier>("c")));
+  std::vector<std::variant<std::unique_ptr<vAST::BehavioralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
       body;
-  vAST::BlockingAssign assign0(&a, &b);
-  body.push_back(&assign0);
-  vAST::NonBlockingAssign assign1(&b, &c);
-  body.push_back(&assign1);
-  vAST::Always always(sensitivity_list, body);
+  body.push_back(std::make_unique<vAST::BlockingAssign>(
+      std::make_unique<vAST::Identifier>("a"),
+      std::make_unique<vAST::Identifier>("b")));
+  body.push_back(std::make_unique<vAST::NonBlockingAssign>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::Identifier>("c")));
+  vAST::Always always(std::move(sensitivity_list), std::move(body));
   std::string expected_str =
       "always @(a, posedge b, negedge c) begin\n"
       "a = b;\n"
       "b <= c;\n"
       "end\n";
   EXPECT_EQ(always.toString(), expected_str);
+}
 
-  sensitivity_list.clear();
-  vAST::Star star;
-  sensitivity_list.push_back(&star);
-  vAST::Always always_star(sensitivity_list, body);
-  expected_str =
+TEST(BasicTests, TestAlwaysStar) {
+  std::vector<std::variant<
+      std::unique_ptr<vAST::Identifier>, std::unique_ptr<vAST::PosEdge>,
+      std::unique_ptr<vAST::NegEdge>, std::unique_ptr<vAST::Star>>>
+      sensitivity_list;
+  std::vector<std::variant<std::unique_ptr<vAST::BehavioralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+  body.push_back(std::make_unique<vAST::BlockingAssign>(
+      std::make_unique<vAST::Identifier>("a"),
+      std::make_unique<vAST::Identifier>("b")));
+  body.push_back(std::make_unique<vAST::NonBlockingAssign>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::Identifier>("c")));
+  sensitivity_list.push_back(std::make_unique<vAST::Star>());
+  vAST::Always always_star(std::move(sensitivity_list), std::move(body));
+  std::string expected_str =
       "always @(*) begin\n"
       "a = b;\n"
       "b <= c;\n"
       "end\n";
   EXPECT_EQ(always_star.toString(), expected_str);
+}
 
-  sensitivity_list.clear();
-  ASSERT_THROW(vAST::Always always_empty(sensitivity_list, body),
+TEST(BasicTests, TestAlwaysEmpty) {
+  std::vector<std::variant<
+      std::unique_ptr<vAST::Identifier>, std::unique_ptr<vAST::PosEdge>,
+      std::unique_ptr<vAST::NegEdge>, std::unique_ptr<vAST::Star>>>
+      sensitivity_list;
+  std::vector<std::variant<std::unique_ptr<vAST::BehavioralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+
+  ASSERT_THROW(vAST::Always always_empty(std::move(sensitivity_list), std::move(body)),
                std::runtime_error);
 }
 
 TEST(BasicTests, File) {
-  vAST::Identifier i("i");
-  vAST::Port i_port(&i, vAST::INPUT, vAST::WIRE);
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports0;
+  ports0.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
+  ports0.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
 
-  vAST::Identifier o("o");
-  vAST::Port o_port(&o, vAST::OUTPUT, vAST::WIRE);
-
-  std::vector<vAST::AbstractPort *> ports = {&i_port, &o_port};
-
-  std::vector<std::variant<vAST::StructuralStatement *, vAST::Declaration *>>
-      body;
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body0;
 
   std::string module_name = "other_module";
-
-  vAST::NumericLiteral zero("0");
-  vAST::NumericLiteral one("1");
-  vAST::Identifier param0("param0");
-  vAST::Identifier param1("param1");
-
-  vAST::Parameters inst_parameters = {{&param0, &zero}, {&param1, &one}};
-
   std::string instance_name = "other_module_inst";
-  vAST::Identifier a("a");
-  vAST::Identifier b("b");
-  vAST::Index b_index(&b, &zero);
-  vAST::Identifier c("c");
-  vAST::NumericLiteral high("31");
-  vAST::NumericLiteral low("0");
-  vAST::Slice c_slice(&c, &high, &low);
 
-  std::map<std::string,
-           std::variant<vAST::Identifier *, vAST::Index *, vAST::Slice *>>
-      connections = {{"a", &a}, {"b", &b_index}, {"c", &c_slice}};
+  vAST::Parameters inst_parameters;
+  inst_parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  inst_parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
 
-  vAST::ModuleInstantiation module_inst(module_name, inst_parameters,
-                                        instance_name, connections);
-  body.push_back(&module_inst);
+  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
+                                     std::unique_ptr<vAST::Index>,
+                                     std::unique_ptr<vAST::Slice>>>
+      connections;
+  connections["a"] = std::make_unique<vAST::Identifier>("a");
+  connections["b"] = std::make_unique<vAST::Index>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+  connections["c"] = std::make_unique<vAST::Slice>(
+      std::make_unique<vAST::Identifier>("c"),
+      std::make_unique<vAST::NumericLiteral>("31"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+
+  body0.push_back(std::make_unique<vAST::ModuleInstantiation>(
+      module_name, std::move(inst_parameters), instance_name, std::move(connections)));
+
+  std::vector<std::unique_ptr<vAST::AbstractModule>> modules;
+  vAST::Parameters parameters0;
+  modules.push_back(
+      std::make_unique<vAST::Module>("test_module0", std::move(ports0), std::move(body0), std::move(parameters0)));
+
+  vAST::Parameters parameters1;
+  parameters1.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  parameters1.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports1;
+  ports1.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
+  ports1.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
+
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body1;
+
+  module_name = "other_module";
+  instance_name = "other_module_inst";
+
+  vAST::Parameters inst_parameters0;
+  inst_parameters0.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  inst_parameters0.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
+
+  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
+                                     std::unique_ptr<vAST::Index>,
+                                     std::unique_ptr<vAST::Slice>>>
+      connections0;
+  connections0["a"] = std::make_unique<vAST::Identifier>("a");
+  connections0["b"] = std::make_unique<vAST::Index>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+  connections0["c"] = std::make_unique<vAST::Slice>(
+      std::make_unique<vAST::Identifier>("c"),
+      std::make_unique<vAST::NumericLiteral>("31"),
+      std::make_unique<vAST::NumericLiteral>("0"));
+
+  body1.push_back(std::make_unique<vAST::ModuleInstantiation>(
+      module_name, std::move(inst_parameters0), instance_name, std::move(connections0)));
 
   vAST::Parameters parameters;
-  vAST::Module module("test_module0", ports, body, parameters);
-  parameters = {{&param0, &zero}, {&param1, &one}};
-  vAST::Module module_with_params("test_module1", ports, body, parameters);
-  std::vector<vAST::AbstractModule *> modules;
-  modules.push_back(&module);
-  modules.push_back(&module_with_params);
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
+                     std::make_unique<vAST::NumericLiteral>("0")));
+  parameters.push_back(
+      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
+                     std::make_unique<vAST::NumericLiteral>("1")));
+
+  modules.push_back(
+      std::make_unique<vAST::Module>("test_module1", std::move(ports1), std::move(body1), std::move(parameters)));
+
   vAST::File file(modules);
 
   std::string expected_str =

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -167,21 +167,8 @@ TEST(BasicTests, TestModuleInst) {
 TEST(BasicTests, TestModule) {
   std::string name = "test_module";
 
-  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
-                           std::unique_ptr<vAST::Declaration>>>
-      body;
-
-  std::string module_name = "other_module";
-  std::string instance_name = "other_module_inst";
-
-  vAST::Parameters inst_parameters = make_simple_params();
-
-  body.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, std::move(inst_parameters), instance_name,
-      make_simple_connections()));
-
   vAST::Parameters parameters;
-  vAST::Module module(name, make_simple_ports(), std::move(body),
+  vAST::Module module(name, make_simple_ports(), make_simple_body(),
                       std::move(parameters));
 
   std::string expected_str =
@@ -194,23 +181,8 @@ TEST(BasicTests, TestModule) {
 TEST(BasicTests, TestParamModule) {
   std::string name = "test_module";
 
-  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
-                           std::unique_ptr<vAST::Declaration>>>
-      body;
-
-  std::string module_name = "other_module";
-
-  vAST::Parameters inst_parameters = make_simple_params();
-
-  std::string instance_name = "other_module_inst";
-
-  body.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, std::move(inst_parameters), instance_name,
-      make_simple_connections()));
-
-  vAST::Parameters parameters = make_simple_params();
-  vAST::Module module_with_params(name, make_simple_ports(), std::move(body),
-                                  std::move(parameters));
+  vAST::Module module_with_params(name, make_simple_ports(), make_simple_body(),
+                                  make_simple_params());
 
   std::string expected_str =
       "module test_module #(parameter param0 = 0, parameter param1 = "
@@ -222,10 +194,6 @@ TEST(BasicTests, TestParamModule) {
 
 TEST(BasicTests, TestStringBodyModule) {
   std::string name = "test_module";
-
-  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
-                           std::unique_ptr<vAST::Declaration>>>
-      body;
 
   std::string module_name = "other_module";
 
@@ -349,37 +317,15 @@ TEST(BasicTests, TestAlwaysEmpty) {
 }
 
 TEST(BasicTests, File) {
-  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
-                           std::unique_ptr<vAST::Declaration>>>
-      body0;
-
-  std::string module_name = "other_module";
-  std::string instance_name = "other_module_inst";
-
-  body0.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, make_simple_params(), instance_name,
-      make_simple_connections()));
-
   std::vector<std::unique_ptr<vAST::AbstractModule>> modules;
   vAST::Parameters parameters0;
-  modules.push_back(
-      std::make_unique<vAST::Module>("test_module0", make_simple_ports(),
-                                     std::move(body0), std::move(parameters0)));
-
-  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
-                           std::unique_ptr<vAST::Declaration>>>
-      body1;
-
-  module_name = "other_module";
-  instance_name = "other_module_inst";
-
-  body1.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, make_simple_params(), instance_name,
-      make_simple_connections()));
+  modules.push_back(std::make_unique<vAST::Module>(
+      "test_module0", make_simple_ports(), make_simple_body(),
+      std::move(parameters0)));
 
   modules.push_back(
       std::make_unique<vAST::Module>("test_module1", make_simple_ports(),
-                                     std::move(body1), make_simple_params()));
+                                     make_simple_body(), make_simple_params()));
 
   vAST::File file(modules);
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -114,6 +114,14 @@ TEST(BasicTests, TestTernaryOp) {
   EXPECT_EQ(tern_op.toString(), "~ x ? 1 : 0");
 }
 
+TEST(BasicTests, TestConcat) {
+  std::vector<std::unique_ptr<vAST::Expression>> args;
+  args.push_back(vAST::make_id("x"));
+  args.push_back(vAST::make_id("y"));
+  vAST::Concat concat(std::move(args));
+  EXPECT_EQ(concat.toString(), "{x,y}");
+}
+
 TEST(BasicTests, TestNegEdge) {
   vAST::NegEdge neg_edge(vAST::make_id("clk"));
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -1,3 +1,4 @@
+#include "common.cpp"
 #include "gtest/gtest.h"
 #include "verilogAST.hpp"
 
@@ -42,23 +43,18 @@ TEST(BasicTests, TestString) {
 }
 
 TEST(BasicTests, TestIndex) {
-  vAST::Index index(std::make_unique<vAST::Identifier>("x"),
-                    std::make_unique<vAST::NumericLiteral>("0"));
+  vAST::Index index(make_id("x"), make_num("0"));
   EXPECT_EQ(index.toString(), "x[0]");
 }
 
 TEST(BasicTests, TestSlice) {
   vAST::Identifier id("x");
-  vAST::Slice slice(std::make_unique<vAST::Identifier>("x"),
-                    std::make_unique<vAST::NumericLiteral>("31"),
-                    std::make_unique<vAST::NumericLiteral>("0"));
+  vAST::Slice slice(make_id("x"), make_num("31"), make_num("0"));
   EXPECT_EQ(slice.toString(), "x[31:0]");
 }
 
 TEST(BasicTests, TestVector) {
-  vAST::Vector slice(std::make_unique<vAST::Identifier>("x"),
-                     std::make_unique<vAST::NumericLiteral>("31"),
-                     std::make_unique<vAST::NumericLiteral>("0"));
+  vAST::Vector slice(make_id("x"), make_num("31"), make_num("0"));
   EXPECT_EQ(slice.toString(), "[31:0] x");
 }
 
@@ -81,8 +77,7 @@ TEST(BasicTests, TestBinaryOp) {
   for (auto it : ops) {
     vAST::BinOp::BinOp op = it.first;
     std::string op_str = it.second;
-    vAST::BinaryOp bin_op(std::make_unique<vAST::Identifier>("x"), op,
-                          std::make_unique<vAST::Identifier>("y"));
+    vAST::BinaryOp bin_op(make_id("x"), op, make_id("y"));
     EXPECT_EQ(bin_op.toString(), "x " + op_str + " y");
   }
 }
@@ -103,7 +98,7 @@ TEST(BasicTests, TestUnaryOp) {
   for (auto it : ops) {
     vAST::UnOp::UnOp op = it.first;
     std::string op_str = it.second;
-    vAST::UnaryOp un_op(std::make_unique<vAST::Identifier>("x"), op);
+    vAST::UnaryOp un_op(make_id("x"), op);
     EXPECT_EQ(un_op.toString(), op_str + " x");
   }
 }
@@ -112,43 +107,37 @@ TEST(BasicTests, TestTernaryOp) {
   vAST::UnaryOp un_op(std::make_unique<vAST::Identifier>("x"),
                       vAST::UnOp::INVERT);
   vAST::TernaryOp tern_op(
-      std::make_unique<vAST::UnaryOp>(std::make_unique<vAST::Identifier>("x"),
-                                      vAST::UnOp::INVERT),
-      std::make_unique<vAST::NumericLiteral>("1"),
-      std::make_unique<vAST::NumericLiteral>("0"));
+      std::make_unique<vAST::UnaryOp>(make_id("x"), vAST::UnOp::INVERT),
+      make_num("1"), make_num("0"));
   EXPECT_EQ(tern_op.toString(), "~ x ? 1 : 0");
 }
 
 TEST(BasicTests, TestNegEdge) {
-  vAST::NegEdge neg_edge(std::make_unique<vAST::Identifier>("clk"));
+  vAST::NegEdge neg_edge(make_id("clk"));
 
   EXPECT_EQ(neg_edge.toString(), "negedge clk");
 }
 
 TEST(BasicTests, TestPosEdge) {
-  vAST::PosEdge pos_edge(std::make_unique<vAST::Identifier>("clk"));
+  vAST::PosEdge pos_edge(make_id("clk"));
 
   EXPECT_EQ(pos_edge.toString(), "posedge clk");
 }
 
 TEST(BasicTests, TestPort) {
-  vAST::Port i_port(std::make_unique<vAST::Identifier>("i"), vAST::INPUT,
-                    vAST::WIRE);
+  vAST::Port i_port(make_id("i"), vAST::INPUT, vAST::WIRE);
 
   EXPECT_EQ(i_port.toString(), "input i");
 
-  vAST::Port o_port(std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT,
-                    vAST::WIRE);
+  vAST::Port o_port(make_id("o"), vAST::OUTPUT, vAST::WIRE);
 
   EXPECT_EQ(o_port.toString(), "output o");
 
-  vAST::Port io_port(std::make_unique<vAST::Identifier>("io"), vAST::INOUT,
-                     vAST::WIRE);
+  vAST::Port io_port(make_id("io"), vAST::INOUT, vAST::WIRE);
 
   EXPECT_EQ(io_port.toString(), "inout io");
 
-  vAST::Port o_reg_port(std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT,
-                        vAST::REG);
+  vAST::Port o_reg_port(make_id("o"), vAST::OUTPUT, vAST::REG);
 
   EXPECT_EQ(o_reg_port.toString(), "output reg o");
 }
@@ -162,37 +151,13 @@ TEST(BasicTests, TestStringPort) {
 TEST(BasicTests, TestModuleInst) {
   std::string module_name = "test_module";
 
-  vAST::Parameters parameters;
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
+  vAST::Parameters parameters = make_simple_params();
 
   std::string instance_name = "test_module_inst";
-  vAST::Identifier a("a");
-  vAST::Index b_index(std::make_unique<vAST::Identifier>("b"),
-                      std::make_unique<vAST::NumericLiteral>("0"));
-  vAST::Slice c_slice(std::make_unique<vAST::Identifier>("c"),
-                      std::make_unique<vAST::NumericLiteral>("31"),
-                      std::make_unique<vAST::NumericLiteral>("0"));
 
-  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
-                                     std::unique_ptr<vAST::Index>,
-                                     std::unique_ptr<vAST::Slice>>>
-      connections;
-  connections["a"] = std::make_unique<vAST::Identifier>("a");
-  connections["b"] = std::make_unique<vAST::Index>(
-      std::make_unique<vAST::Identifier>("b"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-  connections["c"] = std::make_unique<vAST::Slice>(
-      std::make_unique<vAST::Identifier>("c"),
-      std::make_unique<vAST::NumericLiteral>("31"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-
-  vAST::ModuleInstantiation module_inst(module_name, std::move(parameters), instance_name,
-                                        std::move(connections));
+  vAST::ModuleInstantiation module_inst(module_name, std::move(parameters),
+                                        instance_name,
+                                        make_simple_connections());
 
   EXPECT_EQ(module_inst.toString(),
             "test_module #(.param0(0), .param1(1)) "
@@ -202,52 +167,22 @@ TEST(BasicTests, TestModuleInst) {
 TEST(BasicTests, TestModule) {
   std::string name = "test_module";
 
-  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
-  ports.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
-  ports.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
-
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body;
 
   std::string module_name = "other_module";
-
-  vAST::Parameters inst_parameters;
-  inst_parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  inst_parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
-
   std::string instance_name = "other_module_inst";
-  vAST::Identifier a("a");
-  vAST::Index b_index(std::make_unique<vAST::Identifier>("b"),
-                      std::make_unique<vAST::NumericLiteral>("0"));
-  vAST::Slice c_slice(std::make_unique<vAST::Identifier>("c"),
-                      std::make_unique<vAST::NumericLiteral>("31"),
-                      std::make_unique<vAST::NumericLiteral>("0"));
 
-  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
-                                     std::unique_ptr<vAST::Index>,
-                                     std::unique_ptr<vAST::Slice>>>
-      connections;
-  connections["a"] = std::make_unique<vAST::Identifier>("a");
-  connections["b"] = std::make_unique<vAST::Index>(
-      std::make_unique<vAST::Identifier>("b"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-  connections["c"] = std::make_unique<vAST::Slice>(
-      std::make_unique<vAST::Identifier>("c"),
-      std::make_unique<vAST::NumericLiteral>("31"),
-      std::make_unique<vAST::NumericLiteral>("0"));
+  vAST::Parameters inst_parameters = make_simple_params();
 
   body.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, std::move(inst_parameters), instance_name, std::move(connections)));
+      module_name, std::move(inst_parameters), instance_name,
+      make_simple_connections()));
 
   vAST::Parameters parameters;
-  vAST::Module module(name, std::move(ports), std::move(body), std::move(parameters));
+  vAST::Module module(name, make_simple_ports(), std::move(body),
+                      std::move(parameters));
 
   std::string expected_str =
       "module test_module (input i, output o);\nother_module #(.param0(0), "
@@ -259,58 +194,23 @@ TEST(BasicTests, TestModule) {
 TEST(BasicTests, TestParamModule) {
   std::string name = "test_module";
 
-  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
-  ports.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
-  ports.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
-
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body;
 
   std::string module_name = "other_module";
 
-  vAST::Parameters inst_parameters;
-  inst_parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  inst_parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
+  vAST::Parameters inst_parameters = make_simple_params();
 
   std::string instance_name = "other_module_inst";
-  vAST::Identifier a("a");
-  vAST::Index b_index(std::make_unique<vAST::Identifier>("b"),
-                      std::make_unique<vAST::NumericLiteral>("0"));
-  vAST::Slice c_slice(std::make_unique<vAST::Identifier>("c"),
-                      std::make_unique<vAST::NumericLiteral>("31"),
-                      std::make_unique<vAST::NumericLiteral>("0"));
-
-  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
-                                     std::unique_ptr<vAST::Index>,
-                                     std::unique_ptr<vAST::Slice>>>
-      connections;
-  connections["a"] = std::make_unique<vAST::Identifier>("a");
-  connections["b"] = std::make_unique<vAST::Index>(
-      std::make_unique<vAST::Identifier>("b"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-  connections["c"] = std::make_unique<vAST::Slice>(
-      std::make_unique<vAST::Identifier>("c"),
-      std::make_unique<vAST::NumericLiteral>("31"),
-      std::make_unique<vAST::NumericLiteral>("0"));
 
   body.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, std::move(inst_parameters), instance_name, std::move(connections)));
+      module_name, std::move(inst_parameters), instance_name,
+      make_simple_connections()));
 
-  vAST::Parameters parameters;
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
-  vAST::Module module_with_params(name, std::move(ports), std::move(body), std::move(parameters));
+  vAST::Parameters parameters = make_simple_params();
+  vAST::Module module_with_params(name, make_simple_ports(), std::move(body),
+                                  std::move(parameters));
 
   std::string expected_str =
       "module test_module #(parameter param0 = 0, parameter param1 = "
@@ -323,28 +223,15 @@ TEST(BasicTests, TestParamModule) {
 TEST(BasicTests, TestStringBodyModule) {
   std::string name = "test_module";
 
-  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
-  ports.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
-  ports.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
-
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body;
-  vAST::Parameters parameters;
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
 
   std::string module_name = "other_module";
 
   std::string string_body = "reg d;\nassign d = a + b;\nassign c = d;";
-  vAST::StringBodyModule string_body_module(name, std::move(ports), string_body,
-                                            std::move(parameters));
+  vAST::StringBodyModule string_body_module(name, make_simple_ports(),
+                                            string_body, make_simple_params());
   std::string expected_str =
       "module test_module #(parameter param0 = 0, parameter param1 = "
       "1) (input i, output o);\nreg d;\nassign d = a + b;\nassign c = "
@@ -456,17 +343,12 @@ TEST(BasicTests, TestAlwaysEmpty) {
                            std::unique_ptr<vAST::Declaration>>>
       body;
 
-  ASSERT_THROW(vAST::Always always_empty(std::move(sensitivity_list), std::move(body)),
-               std::runtime_error);
+  ASSERT_THROW(
+      vAST::Always always_empty(std::move(sensitivity_list), std::move(body)),
+      std::runtime_error);
 }
 
 TEST(BasicTests, File) {
-  std::vector<std::unique_ptr<vAST::AbstractPort>> ports0;
-  ports0.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
-  ports0.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
-
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body0;
@@ -474,47 +356,15 @@ TEST(BasicTests, File) {
   std::string module_name = "other_module";
   std::string instance_name = "other_module_inst";
 
-  vAST::Parameters inst_parameters;
-  inst_parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  inst_parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
-
-  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
-                                     std::unique_ptr<vAST::Index>,
-                                     std::unique_ptr<vAST::Slice>>>
-      connections;
-  connections["a"] = std::make_unique<vAST::Identifier>("a");
-  connections["b"] = std::make_unique<vAST::Index>(
-      std::make_unique<vAST::Identifier>("b"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-  connections["c"] = std::make_unique<vAST::Slice>(
-      std::make_unique<vAST::Identifier>("c"),
-      std::make_unique<vAST::NumericLiteral>("31"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-
   body0.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, std::move(inst_parameters), instance_name, std::move(connections)));
+      module_name, make_simple_params(), instance_name,
+      make_simple_connections()));
 
   std::vector<std::unique_ptr<vAST::AbstractModule>> modules;
   vAST::Parameters parameters0;
   modules.push_back(
-      std::make_unique<vAST::Module>("test_module0", std::move(ports0), std::move(body0), std::move(parameters0)));
-
-  vAST::Parameters parameters1;
-  parameters1.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  parameters1.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
-  std::vector<std::unique_ptr<vAST::AbstractPort>> ports1;
-  ports1.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("i"), vAST::INPUT, vAST::WIRE));
-  ports1.push_back(std::make_unique<vAST::Port>(
-      std::make_unique<vAST::Identifier>("o"), vAST::OUTPUT, vAST::WIRE));
+      std::make_unique<vAST::Module>("test_module0", make_simple_ports(),
+                                     std::move(body0), std::move(parameters0)));
 
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
@@ -523,40 +373,13 @@ TEST(BasicTests, File) {
   module_name = "other_module";
   instance_name = "other_module_inst";
 
-  vAST::Parameters inst_parameters0;
-  inst_parameters0.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  inst_parameters0.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
-
-  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
-                                     std::unique_ptr<vAST::Index>,
-                                     std::unique_ptr<vAST::Slice>>>
-      connections0;
-  connections0["a"] = std::make_unique<vAST::Identifier>("a");
-  connections0["b"] = std::make_unique<vAST::Index>(
-      std::make_unique<vAST::Identifier>("b"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-  connections0["c"] = std::make_unique<vAST::Slice>(
-      std::make_unique<vAST::Identifier>("c"),
-      std::make_unique<vAST::NumericLiteral>("31"),
-      std::make_unique<vAST::NumericLiteral>("0"));
-
   body1.push_back(std::make_unique<vAST::ModuleInstantiation>(
-      module_name, std::move(inst_parameters0), instance_name, std::move(connections0)));
-
-  vAST::Parameters parameters;
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param0"),
-                     std::make_unique<vAST::NumericLiteral>("0")));
-  parameters.push_back(
-      std::make_pair(std::make_unique<vAST::Identifier>("param1"),
-                     std::make_unique<vAST::NumericLiteral>("1")));
+      module_name, make_simple_params(), instance_name,
+      make_simple_connections()));
 
   modules.push_back(
-      std::make_unique<vAST::Module>("test_module1", std::move(ports1), std::move(body1), std::move(parameters)));
+      std::make_unique<vAST::Module>("test_module1", make_simple_ports(),
+                                     std::move(body1), make_simple_params()));
 
   vAST::File file(modules);
 

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -13,11 +13,13 @@ vAST::Parameters make_simple_params() {
 
 std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
                                    std::unique_ptr<vAST::Index>,
-                                   std::unique_ptr<vAST::Slice>>>
+                                   std::unique_ptr<vAST::Slice>,
+                                   std::unique_ptr<vAST::Concat>>>
 make_simple_connections() {
   std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
                                      std::unique_ptr<vAST::Index>,
-                                     std::unique_ptr<vAST::Slice>>>
+                                     std::unique_ptr<vAST::Slice>,
+                                     std::unique_ptr<vAST::Concat>>>
       connections;
   connections["a"] = vAST::make_id("a");
   connections["b"] =

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -63,3 +63,18 @@ std::vector<std::unique_ptr<vAST::AbstractPort>> make_simple_ports() {
       std::make_unique<vAST::Port>(make_id("o"), vAST::OUTPUT, vAST::WIRE));
   return ports;
 }
+
+std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+    std::unique_ptr<vAST::Declaration>>> make_simple_body() {
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+
+  std::string module_name = "other_module";
+  std::string instance_name = "other_module_inst";
+
+  body.push_back(std::make_unique<vAST::ModuleInstantiation>(
+      module_name, make_simple_params(), instance_name,
+      make_simple_connections()));
+  return body;
+}

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -1,0 +1,65 @@
+#include "verilogAST.hpp"
+
+namespace vAST = verilogAST;
+
+std::unique_ptr<vAST::Identifier> make_id(std::string name) {
+  return std::make_unique<vAST::Identifier>(name);
+}
+
+std::unique_ptr<vAST::NumericLiteral> make_num(std::string val) {
+  return std::make_unique<vAST::NumericLiteral>(val);
+}
+
+std::unique_ptr<vAST::BinaryOp> make_binop(
+    std::unique_ptr<vAST::Expression> left, vAST::BinOp::BinOp op,
+    std::unique_ptr<vAST::Expression> right) {
+  return std::make_unique<vAST::BinaryOp>(std::move(left), op,
+                                          std::move(right));
+}
+
+std::unique_ptr<vAST::Port> make_port(
+    std::variant<std::unique_ptr<vAST::Identifier>,
+                 std::unique_ptr<vAST::Vector>>
+        value,
+    vAST::Direction direction, vAST::PortType data_type) {
+  return std::make_unique<vAST::Port>(std::move(value), direction, data_type);
+}
+
+std::unique_ptr<vAST::Vector> make_vector(
+    std::unique_ptr<vAST::Identifier> id, std::unique_ptr<vAST::Expression> msb,
+    std::unique_ptr<vAST::Expression> lsb) {
+  return std::make_unique<vAST::Vector>(std::move(id), std::move(msb),
+                                        std::move(lsb));
+}
+
+vAST::Parameters make_simple_params() {
+  vAST::Parameters parameters;
+  parameters.push_back(std::make_pair(make_id("param0"), make_num("0")));
+  parameters.push_back(std::make_pair(make_id("param1"), make_num("1")));
+  return parameters;
+}
+
+std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
+                                   std::unique_ptr<vAST::Index>,
+                                   std::unique_ptr<vAST::Slice>>>
+make_simple_connections() {
+  std::map<std::string, std::variant<std::unique_ptr<vAST::Identifier>,
+                                     std::unique_ptr<vAST::Index>,
+                                     std::unique_ptr<vAST::Slice>>>
+      connections;
+  connections["a"] = make_id("a");
+  connections["b"] = std::make_unique<vAST::Index>(make_id("b"), make_num("0"));
+  connections["c"] = std::make_unique<vAST::Slice>(make_id("c"), make_num("31"),
+                                                   make_num("0"));
+
+  return connections;
+}
+
+std::vector<std::unique_ptr<vAST::AbstractPort>> make_simple_ports() {
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(
+      std::make_unique<vAST::Port>(make_id("i"), vAST::INPUT, vAST::WIRE));
+  ports.push_back(
+      std::make_unique<vAST::Port>(make_id("o"), vAST::OUTPUT, vAST::WIRE));
+  return ports;
+}

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -65,7 +65,8 @@ std::vector<std::unique_ptr<vAST::AbstractPort>> make_simple_ports() {
 }
 
 std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
-    std::unique_ptr<vAST::Declaration>>> make_simple_body() {
+                         std::unique_ptr<vAST::Declaration>>>
+make_simple_body() {
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body;
@@ -76,5 +77,21 @@ std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
   body.push_back(std::make_unique<vAST::ModuleInstantiation>(
       module_name, make_simple_params(), instance_name,
       make_simple_connections()));
+  return body;
+}
+
+std::vector<std::variant<std::unique_ptr<vAST::BehavioralStatement>,
+                         std::unique_ptr<vAST::Declaration>>>
+make_simple_always_body() {
+  std::vector<std::variant<std::unique_ptr<vAST::BehavioralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+  body.push_back(std::make_unique<vAST::BlockingAssign>(
+      std::make_unique<vAST::Identifier>("a"),
+      std::make_unique<vAST::Identifier>("b")));
+  body.push_back(std::make_unique<vAST::NonBlockingAssign>(
+      std::make_unique<vAST::Identifier>("b"),
+      std::make_unique<vAST::Identifier>("c")));
+
   return body;
 }

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -2,40 +2,12 @@
 
 namespace vAST = verilogAST;
 
-std::unique_ptr<vAST::Identifier> make_id(std::string name) {
-  return std::make_unique<vAST::Identifier>(name);
-}
-
-std::unique_ptr<vAST::NumericLiteral> make_num(std::string val) {
-  return std::make_unique<vAST::NumericLiteral>(val);
-}
-
-std::unique_ptr<vAST::BinaryOp> make_binop(
-    std::unique_ptr<vAST::Expression> left, vAST::BinOp::BinOp op,
-    std::unique_ptr<vAST::Expression> right) {
-  return std::make_unique<vAST::BinaryOp>(std::move(left), op,
-                                          std::move(right));
-}
-
-std::unique_ptr<vAST::Port> make_port(
-    std::variant<std::unique_ptr<vAST::Identifier>,
-                 std::unique_ptr<vAST::Vector>>
-        value,
-    vAST::Direction direction, vAST::PortType data_type) {
-  return std::make_unique<vAST::Port>(std::move(value), direction, data_type);
-}
-
-std::unique_ptr<vAST::Vector> make_vector(
-    std::unique_ptr<vAST::Identifier> id, std::unique_ptr<vAST::Expression> msb,
-    std::unique_ptr<vAST::Expression> lsb) {
-  return std::make_unique<vAST::Vector>(std::move(id), std::move(msb),
-                                        std::move(lsb));
-}
-
 vAST::Parameters make_simple_params() {
   vAST::Parameters parameters;
-  parameters.push_back(std::make_pair(make_id("param0"), make_num("0")));
-  parameters.push_back(std::make_pair(make_id("param1"), make_num("1")));
+  parameters.push_back(
+      std::make_pair(vAST::make_id("param0"), vAST::make_num("0")));
+  parameters.push_back(
+      std::make_pair(vAST::make_id("param1"), vAST::make_num("1")));
   return parameters;
 }
 
@@ -47,20 +19,21 @@ make_simple_connections() {
                                      std::unique_ptr<vAST::Index>,
                                      std::unique_ptr<vAST::Slice>>>
       connections;
-  connections["a"] = make_id("a");
-  connections["b"] = std::make_unique<vAST::Index>(make_id("b"), make_num("0"));
-  connections["c"] = std::make_unique<vAST::Slice>(make_id("c"), make_num("31"),
-                                                   make_num("0"));
+  connections["a"] = vAST::make_id("a");
+  connections["b"] =
+      std::make_unique<vAST::Index>(vAST::make_id("b"), vAST::make_num("0"));
+  connections["c"] = std::make_unique<vAST::Slice>(
+      vAST::make_id("c"), vAST::make_num("31"), vAST::make_num("0"));
 
   return connections;
 }
 
 std::vector<std::unique_ptr<vAST::AbstractPort>> make_simple_ports() {
   std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
-  ports.push_back(
-      std::make_unique<vAST::Port>(make_id("i"), vAST::INPUT, vAST::WIRE));
-  ports.push_back(
-      std::make_unique<vAST::Port>(make_id("o"), vAST::OUTPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(vAST::make_id("i"), vAST::INPUT,
+                                               vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(vAST::make_id("o"), vAST::OUTPUT,
+                                               vAST::WIRE));
   return ports;
 }
 

--- a/tests/parameterized_module.cpp
+++ b/tests/parameterized_module.cpp
@@ -1,3 +1,4 @@
+#include "common.cpp"
 #include "gtest/gtest.h"
 #include "verilogAST.hpp"
 
@@ -21,56 +22,34 @@ namespace {
 TEST(ParameterizedModuleTests, TestEq) {
   std::string name = "coreir_eq";
 
-  std::unique_ptr<vAST::Identifier> in0 =
-      std::make_unique<vAST::Identifier>("in0");
-  std::unique_ptr<vAST::Identifier> in1 =
-      std::make_unique<vAST::Identifier>("in1");
-  std::unique_ptr<vAST::Identifier> out =
-      std::make_unique<vAST::Identifier>("out");
-
-  std::unique_ptr<vAST::Vector> in0_vec = std::make_unique<vAST::Vector>(
-      std::make_unique<vAST::Identifier>("in0"),
-      std::make_unique<vAST::BinaryOp>(std::make_unique<vAST::Identifier>("width"), vAST::BinOp::SUB,
-                                       std::make_unique<vAST::NumericLiteral>("1")),
-      std::make_unique<vAST::NumericLiteral>("0"));
-  std::unique_ptr<vAST::Vector> in1_vec = std::make_unique<vAST::Vector>(
-      std::make_unique<vAST::Identifier>("in1"),
-      std::make_unique<vAST::BinaryOp>(std::make_unique<vAST::Identifier>("width"), vAST::BinOp::SUB,
-                                       std::make_unique<vAST::NumericLiteral>("1")),
-      std::make_unique<vAST::NumericLiteral>("0"));
-
-  std::unique_ptr<vAST::Port> in0_port =
-      std::make_unique<vAST::Port>(std::move(in0_vec), vAST::INPUT, vAST::WIRE);
-  std::unique_ptr<vAST::Port> in1_port =
-      std::make_unique<vAST::Port>(std::move(in1_vec), vAST::INPUT, vAST::WIRE);
-  std::unique_ptr<vAST::Port> out_port =
-      std::make_unique<vAST::Port>(std::make_unique<vAST::Identifier>("out"), vAST::OUTPUT, vAST::WIRE);
-
   std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
-  ports.push_back(std::move(in0_port)); 
-  ports.push_back(std::move(in1_port));
-  ports.push_back(std::move(out_port));
+  ports.push_back(make_port(
+      make_vector(make_id("in0"),
+                  make_binop(make_id("width"), vAST::BinOp::SUB, make_num("1")),
+                  make_num("0")),
+      vAST::INPUT, vAST::WIRE));
+  ports.push_back(make_port(
+      make_vector(make_id("in1"),
+                  make_binop(make_id("width"), vAST::BinOp::SUB, make_num("1")),
+                  make_num("0")),
+      vAST::INPUT, vAST::WIRE));
+  ports.push_back(make_port(make_id("out"), vAST::OUTPUT, vAST::WIRE));
 
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body;
 
-  std::unique_ptr<vAST::BinaryOp> eq_op = std::make_unique<vAST::BinaryOp>(
-      std::make_unique<vAST::Identifier>("in0"), vAST::BinOp::EQ, std::make_unique<vAST::Identifier>("in1"));
   std::unique_ptr<vAST::ContinuousAssign> eq_assign =
-      std::make_unique<vAST::ContinuousAssign>(std::make_unique<vAST::Identifier>("out"),
-                                               std::move(eq_op));
+      std::make_unique<vAST::ContinuousAssign>(
+          make_id("out"),
+          make_binop(make_id("in0"), vAST::BinOp::EQ, make_id("in1")));
 
   body.push_back(std::move(eq_assign));
 
-  std::unique_ptr<vAST::Identifier> width =
-      std::make_unique<vAST::Identifier>("width");
-  std::unique_ptr<vAST::NumericLiteral> one =
-      std::make_unique<vAST::NumericLiteral>("1");
   vAST::Parameters parameters;
-  parameters.push_back(std::make_pair(std::move(width), std::move(one)));
-  std::unique_ptr<vAST::Module> coreir_eq =
-      std::make_unique<vAST::Module>(name, std::move(ports), std::move(body), std::move(parameters));
+  parameters.push_back(std::make_pair(make_id("width"), make_num("1")));
+  std::unique_ptr<vAST::Module> coreir_eq = std::make_unique<vAST::Module>(
+      name, std::move(ports), std::move(body), std::move(parameters));
 
   cout << "//coreir_eq" << endl << coreir_eq->toString() << endl;
   std::string expected_str =

--- a/tests/parameterized_module.cpp
+++ b/tests/parameterized_module.cpp
@@ -20,45 +20,68 @@ namespace {
 
 TEST(ParameterizedModuleTests, TestEq) {
   std::string name = "coreir_eq";
-  
-  vAST::Identifier width("width");
-  vAST::Identifier in0("in0");
-  vAST::Identifier in1("in1");
-  vAST::Identifier out("out");
-  vAST::NumericLiteral one("1");
-  vAST::NumericLiteral zero("0");
-  vAST::BinaryOp hi(&width,vAST::BinOp::SUB,&one);
-  auto lo = zero;
 
-  vAST::Vector in0_vec(&in0, &hi, &lo);
-  vAST::Vector in1_vec(&in1, &hi, &lo);
+  std::unique_ptr<vAST::Identifier> in0 =
+      std::make_unique<vAST::Identifier>("in0");
+  std::unique_ptr<vAST::Identifier> in1 =
+      std::make_unique<vAST::Identifier>("in1");
+  std::unique_ptr<vAST::Identifier> out =
+      std::make_unique<vAST::Identifier>("out");
 
-  vAST::Port in0_port(&in0_vec, vAST::INPUT, vAST::WIRE);
-  vAST::Port in1_port(&in1_vec, vAST::INPUT, vAST::WIRE);
-  vAST::Port out_port(&out, vAST::OUTPUT, vAST::WIRE);
+  std::unique_ptr<vAST::Vector> in0_vec = std::make_unique<vAST::Vector>(
+      std::make_unique<vAST::Identifier>("in0"),
+      std::make_unique<vAST::BinaryOp>(std::make_unique<vAST::Identifier>("width"), vAST::BinOp::SUB,
+                                       std::make_unique<vAST::NumericLiteral>("1")),
+      std::make_unique<vAST::NumericLiteral>("0"));
+  std::unique_ptr<vAST::Vector> in1_vec = std::make_unique<vAST::Vector>(
+      std::make_unique<vAST::Identifier>("in1"),
+      std::make_unique<vAST::BinaryOp>(std::make_unique<vAST::Identifier>("width"), vAST::BinOp::SUB,
+                                       std::make_unique<vAST::NumericLiteral>("1")),
+      std::make_unique<vAST::NumericLiteral>("0"));
 
-  std::vector<vAST::AbstractPort *> ports = {&in0_port, &in1_port, &out_port};
+  std::unique_ptr<vAST::Port> in0_port =
+      std::make_unique<vAST::Port>(std::move(in0_vec), vAST::INPUT, vAST::WIRE);
+  std::unique_ptr<vAST::Port> in1_port =
+      std::make_unique<vAST::Port>(std::move(in1_vec), vAST::INPUT, vAST::WIRE);
+  std::unique_ptr<vAST::Port> out_port =
+      std::make_unique<vAST::Port>(std::make_unique<vAST::Identifier>("out"), vAST::OUTPUT, vAST::WIRE);
 
-  std::vector<std::variant<vAST::StructuralStatement *, vAST::Declaration *>>
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::move(in0_port)); 
+  ports.push_back(std::move(in1_port));
+  ports.push_back(std::move(out_port));
+
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
       body;
 
-  vAST::BinaryOp eq_op(&in0,vAST::BinOp::EQ,&in1);
-  vAST::ContinuousAssign eq_assign(&out, &eq_op);
+  std::unique_ptr<vAST::BinaryOp> eq_op = std::make_unique<vAST::BinaryOp>(
+      std::make_unique<vAST::Identifier>("in0"), vAST::BinOp::EQ, std::make_unique<vAST::Identifier>("in1"));
+  std::unique_ptr<vAST::ContinuousAssign> eq_assign =
+      std::make_unique<vAST::ContinuousAssign>(std::make_unique<vAST::Identifier>("out"),
+                                               std::move(eq_op));
 
-  body.push_back(&eq_assign);
+  body.push_back(std::move(eq_assign));
 
-  vAST::Parameters parameters = {{&width,&one}};
-  vAST::Module coreir_eq(name, ports, body, parameters);
+  std::unique_ptr<vAST::Identifier> width =
+      std::make_unique<vAST::Identifier>("width");
+  std::unique_ptr<vAST::NumericLiteral> one =
+      std::make_unique<vAST::NumericLiteral>("1");
+  vAST::Parameters parameters;
+  parameters.push_back(std::make_pair(std::move(width), std::move(one)));
+  std::unique_ptr<vAST::Module> coreir_eq =
+      std::make_unique<vAST::Module>(name, std::move(ports), std::move(body), std::move(parameters));
 
-  cout << "//coreir_eq" << endl << coreir_eq.toString() << endl;
+  cout << "//coreir_eq" << endl << coreir_eq->toString() << endl;
   std::string expected_str =
-      "module coreir_eq #(parameter width = 1) (input [width - 1:0] in0, input [width - 1:0] in1, output out);\n"
+      "module coreir_eq #(parameter width = 1) (input [width - 1:0] in0, input "
+      "[width - 1:0] in1, output out);\n"
       "assign out = in0 == in1;\n"
       "endmodule\n";
-  EXPECT_EQ(coreir_eq.toString(), expected_str);
+  EXPECT_EQ(coreir_eq->toString(), expected_str);
 }
 
-} // namespace
+}  // namespace
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/parameterized_module.cpp
+++ b/tests/parameterized_module.cpp
@@ -23,17 +23,20 @@ TEST(ParameterizedModuleTests, TestEq) {
   std::string name = "coreir_eq";
 
   std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
-  ports.push_back(make_port(
-      make_vector(make_id("in0"),
-                  make_binop(make_id("width"), vAST::BinOp::SUB, make_num("1")),
-                  make_num("0")),
+  ports.push_back(vAST::make_port(
+      vAST::make_vector(vAST::make_id("in0"),
+                        vAST::make_binop(vAST::make_id("width"),
+                                         vAST::BinOp::SUB, vAST::make_num("1")),
+                        vAST::make_num("0")),
       vAST::INPUT, vAST::WIRE));
-  ports.push_back(make_port(
-      make_vector(make_id("in1"),
-                  make_binop(make_id("width"), vAST::BinOp::SUB, make_num("1")),
-                  make_num("0")),
+  ports.push_back(vAST::make_port(
+      vAST::make_vector(vAST::make_id("in1"),
+                        vAST::make_binop(vAST::make_id("width"),
+                                         vAST::BinOp::SUB, vAST::make_num("1")),
+                        vAST::make_num("0")),
       vAST::INPUT, vAST::WIRE));
-  ports.push_back(make_port(make_id("out"), vAST::OUTPUT, vAST::WIRE));
+  ports.push_back(
+      vAST::make_port(vAST::make_id("out"), vAST::OUTPUT, vAST::WIRE));
 
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
@@ -41,13 +44,15 @@ TEST(ParameterizedModuleTests, TestEq) {
 
   std::unique_ptr<vAST::ContinuousAssign> eq_assign =
       std::make_unique<vAST::ContinuousAssign>(
-          make_id("out"),
-          make_binop(make_id("in0"), vAST::BinOp::EQ, make_id("in1")));
+          vAST::make_id("out"),
+          vAST::make_binop(vAST::make_id("in0"), vAST::BinOp::EQ,
+                           vAST::make_id("in1")));
 
   body.push_back(std::move(eq_assign));
 
   vAST::Parameters parameters;
-  parameters.push_back(std::make_pair(make_id("width"), make_num("1")));
+  parameters.push_back(
+      std::make_pair(vAST::make_id("width"), vAST::make_num("1")));
   std::unique_ptr<vAST::Module> coreir_eq = std::make_unique<vAST::Module>(
       name, std::move(ports), std::move(body), std::move(parameters));
 


### PR DESCRIPTION
Lots of code changes, I don't know how necessary it is to review it in great detail (assuming you trust the test suite), but the main change is to move all the AST nodes to use `unique_ptr` for their children. This enforces that all AST nodes have unique children, simplifying the memory management model (leveraging unique_ptr to clean things up). This prevents users from sharing a single instance of an AST node amongst multiple children. While this approach might exhibit better space consumption, it's likely to lead to problems (e.g. deleting a node when it's being used by someone else). If we think that's a valid use case, we could refactor this to use a shared_ptr model, but I think for now this is simplest and forces users to write code that will likely be easier to maintain (the user can always assume that a node owns all its children).