### PR TITLE
Add Replicate operator

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -197,6 +197,16 @@ class Concat : public Expression {
   std::string toString();
 };
 
+class Replicate : public Expression {
+    std::unique_ptr<Expression> num;
+    std::unique_ptr<Expression> value;
+
+ public:
+  Replicate(std::unique_ptr<Expression> num, std::unique_ptr<Expression> value)
+      : num(std::move(num)), value(std::move(value)){};
+  std::string toString();
+};
+
 class NegEdge : public Expression {
   std::unique_ptr<Expression> value;
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -240,7 +240,8 @@ std::string Concat::toString() {
 }
 
 std::string Replicate::toString() {
-  return "{" + num->toString() + "{" + value->toString() + "}" + "}";
+  // TODO: Insert parens using precedence logic
+  return "{(" + num->toString() + "){" + value->toString() + "}" + "}";
 }
 
 std::string NegEdge::toString() { return "negedge " + value->toString(); }

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -239,6 +239,10 @@ std::string Concat::toString() {
   return "{" + join(arg_strs, ",") + "}";
 }
 
+std::string Replicate::toString() {
+  return "{" + num->toString() + "{" + value->toString() + "}" + "}";
+}
+
 std::string NegEdge::toString() { return "negedge " + value->toString(); }
 
 std::string PosEdge::toString() { return "posedge " + value->toString(); }

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -142,6 +142,11 @@ TEST(BasicTests, TestConcat) {
   EXPECT_EQ(concat.toString(), "{x,y}");
 }
 
+TEST(BasicTests, TestReplicate) {
+  vAST::Replicate replicate(vAST::make_num("3"), vAST::make_num("4"));
+  EXPECT_EQ(replicate.toString(), "{3{5}}");
+}
+
 TEST(BasicTests, TestNegEdge) {
   vAST::NegEdge neg_edge(vAST::make_id("clk"));
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -144,7 +144,12 @@ TEST(BasicTests, TestConcat) {
 
 TEST(BasicTests, TestReplicate) {
   vAST::Replicate replicate(vAST::make_num("3"), vAST::make_num("4"));
-  EXPECT_EQ(replicate.toString(), "{3{5}}");
+  EXPECT_EQ(replicate.toString(), "{(3){4}}");
+}
+
+TEST(BasicTests, TestReplicateExpr) {
+  vAST::Replicate replicate(vAST::make_binop(vAST::make_id("x"), vAST::BinOp::ADD, vAST::make_id("y")), vAST::make_num("4"));
+  EXPECT_EQ(replicate.toString(), "{(x + y){4}}");
 }
 
 TEST(BasicTests, TestNegEdge) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -148,7 +148,10 @@ TEST(BasicTests, TestReplicate) {
 }
 
 TEST(BasicTests, TestReplicateExpr) {
-  vAST::Replicate replicate(vAST::make_binop(vAST::make_id("x"), vAST::BinOp::ADD, vAST::make_id("y")), vAST::make_num("4"));
+  vAST::Replicate replicate(
+      vAST::make_binop(vAST::make_id("x"), vAST::BinOp::ADD,
+                       vAST::make_id("y")),
+      vAST::make_num("4"));
   EXPECT_EQ(replicate.toString(), "{(x + y){4}}");
 }
 


### PR DESCRIPTION
Needed for coreir primitives, for now it always inserts a paren, in the future it should use precedence logic to decide whether they are necessary.