### PR TITLE
Add ability to include inline verilog

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -319,6 +319,15 @@ class BlockComment : public StructuralStatement, public BehavioralStatement {
   ~BlockComment(){};
 };
 
+class InlineVerilog : public StructuralStatement, public BehavioralStatement {
+ public:
+  std::string value;
+
+  InlineVerilog(std::string value) : value(value){};
+  std::string toString() { return value; };
+  ~InlineVerilog(){};
+};
+
 typedef std::vector<
     std::pair<std::unique_ptr<Identifier>, std::unique_ptr<Expression>>>
     Parameters;

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -319,7 +319,11 @@ class BlockComment : public StructuralStatement, public BehavioralStatement {
   ~BlockComment(){};
 };
 
-class InlineVerilog : public StructuralStatement, public BehavioralStatement {
+class InlineVerilog : public StructuralStatement {
+  // Serializes into `value`, so allows the inclusion of arbitrary verilog
+  // statement(s) in the body of a module definition.  The contents of
+  // `value` must be a valid verilog statement inside a module body.  The
+  // contents are not validated.
  public:
   std::string value;
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -395,6 +395,14 @@ TEST(BasicTests, Comment) {
   EXPECT_EQ(block_comment.toString(),
             "/*\nTest comment\non multiple lines\n*/");
 }
+TEST(BasicTests, InlineVerilog) {
+  vAST::InlineVerilog inline_verilog(
+      "logic [1:0] x;\n"
+      "assign x = 2'b10;\n");
+  EXPECT_EQ(inline_verilog.toString(),
+            "logic [1:0] x;\n"
+            "assign x = 2'b10;\n");
+}
 
 }  // namespace
 


### PR DESCRIPTION
Adds a node that serializes to it's value, which allows the passing of inline verilog through the compiler.  This will enable the use of inline verilog in magma (ala pragma asm).  For now magma (or fault rather) will be responsible for interpolating the verilog name in the inline verilog (e.g. referring to a tuple field will need to be mapped to the verilog name).  We can work on more robust/extensible ways to handle this in the future.