### PR TITLE
Add ability to have a commented statement

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -304,9 +304,13 @@ class SingleLineComment : public StructuralStatement,
                           public BehavioralStatement {
  public:
   std::string value;
+  std::unique_ptr<Statement> statement;  // optional
 
-  SingleLineComment(std::string value) : value(value){};
-  std::string toString() { return "// " + value; };
+  SingleLineComment(std::string value)
+      : value(value), statement(std::unique_ptr<Statement>{}){};
+  SingleLineComment(std::string value, std::unique_ptr<Statement> statement)
+      : value(value), statement(std::move(statement)){};
+  std::string toString();
   ~SingleLineComment(){};
 };
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -466,6 +466,6 @@ std::string SingleLineComment::toString() {
     result += this->statement->toString() + "  ";
   }
   return result + "// " + value;
-};
+}
 
 }  // namespace verilogAST

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -186,19 +186,19 @@ std::string BinaryOp::toString() {
   std::string lstr = left->toString();
   std::string rstr = right->toString();
   // TODO Precedence logic, for now we just insert parens if not symbol or num
-  if (dynamic_cast<Identifier*>(left.get())) {
-  } else if (dynamic_cast<NumericLiteral*>(left.get())) {
-  } else if (dynamic_cast<Index*>(left.get())) {
-  } else if (dynamic_cast<Slice*>(left.get())) {
+  if (dynamic_cast<Identifier *>(left.get())) {
+  } else if (dynamic_cast<NumericLiteral *>(left.get())) {
+  } else if (dynamic_cast<Index *>(left.get())) {
+  } else if (dynamic_cast<Slice *>(left.get())) {
   } else {
-      lstr = "(" + lstr + ")";
+    lstr = "(" + lstr + ")";
   }
-  if (dynamic_cast<Identifier*>(right.get())) {
-  } else if (dynamic_cast<NumericLiteral*>(right.get())) {
-  } else if (dynamic_cast<Index*>(right.get())) {
-  } else if (dynamic_cast<Slice*>(right.get())) {
+  if (dynamic_cast<Identifier *>(right.get())) {
+  } else if (dynamic_cast<NumericLiteral *>(right.get())) {
+  } else if (dynamic_cast<Index *>(right.get())) {
+  } else if (dynamic_cast<Slice *>(right.get())) {
   } else {
-      rstr = "(" + rstr + ")";
+    rstr = "(" + rstr + ")";
   }
   return lstr + ' ' + op_str + ' ' + rstr;
 }
@@ -242,12 +242,12 @@ std::string UnaryOp::toString() {
   }
   std::string operand_str = operand->toString();
   // TODO Precedence logic, for now we just insert parens if not symbol or num
-  if (dynamic_cast<Identifier*>(operand.get())) {
-  } else if (dynamic_cast<NumericLiteral*>(operand.get())) {
-  } else if (dynamic_cast<Index*>(operand.get())) {
-  } else if (dynamic_cast<Slice*>(operand.get())) {
+  if (dynamic_cast<Identifier *>(operand.get())) {
+  } else if (dynamic_cast<NumericLiteral *>(operand.get())) {
+  } else if (dynamic_cast<Index *>(operand.get())) {
+  } else if (dynamic_cast<Slice *>(operand.get())) {
   } else {
-      operand_str = "(" + operand_str + ")";
+    operand_str = "(" + operand_str + ")";
   }
   return op_str + ' ' + operand_str;
 }
@@ -459,5 +459,13 @@ std::unique_ptr<Vector> make_vector(std::unique_ptr<Identifier> id,
   return std::make_unique<Vector>(std::move(id), std::move(msb),
                                   std::move(lsb));
 }
+
+std::string SingleLineComment::toString() {
+  std::string result = "";
+  if (this->statement) {
+    result += this->statement->toString() + "  ";
+  }
+  return result + "// " + value;
+};
 
 }  // namespace verilogAST

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -394,6 +394,13 @@ TEST(BasicTests, Comment) {
   vAST::BlockComment block_comment("Test comment\non multiple lines");
   EXPECT_EQ(block_comment.toString(),
             "/*\nTest comment\non multiple lines\n*/");
+  std::unique_ptr<vAST::ContinuousAssign> cont_assign =
+      std::make_unique<vAST::ContinuousAssign>(
+          std::make_unique<vAST::Identifier>("a"),
+          std::make_unique<vAST::Identifier>("b"));
+  vAST::SingleLineComment stmt_with_comment("Test comment",
+                                            std::move(cont_assign));
+  EXPECT_EQ(stmt_with_comment.toString(), "assign a = b;  // Test comment");
 }
 
 }  // namespace


### PR DESCRIPTION
Clang format fixed up some unrelated lines, I can separate out that change, but I figured it was small enough to still be understandable/ignored, but I can factor them out of if needed. 

This just adds an option field `statement` to the single line comment node that allows a comment node to include a statement, which essentially allows us to emit statements that are followed by comments (this was simpler than having all statements have an optional comment, but that would be a valid design too).  This will be used to emit statements that have comments (e.g. filename/line number for mapping back to original name.