### PR TITLE
Support slicing an expression

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -128,22 +128,23 @@ class Index : public Expression {
 class Slice : public Expression {
  protected:
   virtual Slice* clone_impl() const override {
-    return new Slice(this->id->clone(), this->high_index->clone(),
+    return new Slice(this->expr->clone(), this->high_index->clone(),
                      this->low_index->clone());
   };
 
  public:
-  std::unique_ptr<Identifier> id;
+  std::unique_ptr<Expression> expr;
   std::unique_ptr<Expression> high_index;
   std::unique_ptr<Expression> low_index;
 
-  Slice(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> high_index,
+  Slice(std::unique_ptr<Expression> expr,
+        std::unique_ptr<Expression> high_index,
         std::unique_ptr<Expression> low_index)
-      : id(std::move(id)),
+      : expr(std::move(expr)),
         high_index(std::move(high_index)),
         low_index(std::move(low_index)){};
   Slice(const Slice& rhs)
-      : id(rhs.id->clone()),
+      : expr(rhs.expr->clone()),
         high_index(rhs.high_index->clone()),
         low_index(rhs.low_index->clone()){};
   std::string toString() override;

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<Index> Transformer::visit(std::unique_ptr<Index> node) {
 }
 
 std::unique_ptr<Slice> Transformer::visit(std::unique_ptr<Slice> node) {
-  node->id = this->visit(std::move(node->id));
+  node->expr = this->visit(std::move(node->expr));
   node->high_index = this->visit(std::move(node->high_index));
   node->low_index = this->visit(std::move(node->low_index));
   return node;

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -108,8 +108,16 @@ std::string Index::toString() {
 }
 
 std::string Slice::toString() {
-  return id->toString() + '[' + high_index->toString() + ':' +
-         low_index->toString() + ']';
+  std::string expr_str = expr->toString();
+  if (dynamic_cast<Identifier *>(expr.get())) {
+  } else if (dynamic_cast<NumericLiteral *>(expr.get())) {
+  } else if (dynamic_cast<Index *>(expr.get())) {
+  } else if (dynamic_cast<Slice *>(expr.get())) {
+  } else {
+    expr_str = "(" + expr_str + ")";
+  }
+  return expr_str + '[' + high_index->toString() + ':' + low_index->toString() +
+         ']';
 }
 
 std::string Vector::toString() {
@@ -381,8 +389,7 @@ std::string ModuleInstantiation::toString() {
   if (!connections.empty()) {
     std::vector<std::string> param_strs;
     for (auto &it : connections) {
-      param_strs.push_back("." + it.first + "(" + it.second->toString() +
-                           ")");
+      param_strs.push_back("." + it.first + "(" + it.second->toString() + ")");
     }
     module_inst_str += join(param_strs, ", ");
   }

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -110,7 +110,6 @@ std::string Index::toString() {
 std::string Slice::toString() {
   std::string expr_str = expr->toString();
   if (dynamic_cast<Identifier *>(expr.get())) {
-  } else if (dynamic_cast<NumericLiteral *>(expr.get())) {
   } else if (dynamic_cast<Index *>(expr.get())) {
   } else if (dynamic_cast<Slice *>(expr.get())) {
   } else {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -492,7 +492,7 @@ TEST(BasicTests, TestSliceCopy) {
   std::unique_ptr<vAST::Slice> x1 = std::make_unique<vAST::Slice>(*x);
   EXPECT_EQ(x->toString(), "x[y:z]");
   EXPECT_EQ(x1->toString(), "x[y:z]");
-  x1->id = std::make_unique<vAST::Identifier>("a");
+  x1->expr = std::make_unique<vAST::Identifier>("a");
   x1->high_index = std::make_unique<vAST::Identifier>("b");
   x1->low_index = std::make_unique<vAST::Identifier>("c");
   EXPECT_EQ(x->toString(), "x[y:z]");


### PR DESCRIPTION
This enhances the slice node to take an arbitrary expression (rather than just a simple identifier), for now it defaults to wrapping the expression in parens except for simple cases.