### PR TITLE
Use vector of pairs instead of map for instance ports

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -494,6 +494,14 @@ class Connections {
     connections.push_back(std::make_pair(name, std::move(expr)));
   }
 
+  // Releases ownership of expression at @name if exists, othwerwise throws error.
+  std::unique_ptr<Expression> at(std::string name) {
+    auto is_name = [name](auto& element) { return element.first == name; };
+    auto it = std::find_if(connections.begin(), connections.end(), is_name);
+    if (it != connections.end()) return std::move(it->second);
+    throw std::runtime_error("Could not find '" + name + "'");
+  }
+
   ConnectionVector::iterator begin() { return connections.begin(); }
   ConnectionVector::iterator end() { return connections.end(); }
 

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -489,13 +489,14 @@ class ModuleInstantiation : public StructuralStatement {
 
   // map from instance port names to connection expression
   // NOTE: anonymous style of module connections is not supported
-  std::map<std::string, std::unique_ptr<Expression>> connections;
+  std::vector<std::pair<std::string, std::unique_ptr<Expression>>> connections;
 
   // TODO Need to make sure that the instance parameters are a subset of the
   // module parameters
   ModuleInstantiation(
       std::string module_name, Parameters parameters, std::string instance_name,
-      std::map<std::string, std::unique_ptr<Expression>> connections)
+      std::vector<std::pair<std::string, std::unique_ptr<Expression>>>
+          connections)
       : module_name(module_name),
         parameters(std::move(parameters)),
         instance_name(instance_name),

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -505,7 +505,7 @@ class Connections {
   ConnectionVector::iterator begin() { return connections.begin(); }
   ConnectionVector::iterator end() { return connections.end(); }
 
-  bool empty() { return connections.empty(); }
+  bool empty() const { return connections.empty(); }
 
  private:
   ConnectionVector connections;

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -478,6 +478,31 @@ typedef std::vector<
     std::pair<std::unique_ptr<Identifier>, std::unique_ptr<Expression>>>
     Parameters;
 
+typedef std::vector<std::pair<std::string, std::unique_ptr<Expression>>>
+    ConnectionVector;
+
+class Connections {
+ public:
+  Connections() : connections() {}
+  ~Connections() = default;
+
+  // Non-copyable class
+  Connections(const Connections&) = delete;
+
+  // Takes ownership of @expr.
+  void insert(std::string name, std::unique_ptr<Expression> expr) {
+    connections.push_back(std::make_pair(name, std::move(expr)));
+  }
+
+  ConnectionVector::iterator begin() { return connections.begin(); }
+  ConnectionVector::iterator end() { return connections.end(); }
+
+  bool empty() { return connections.empty(); }
+
+ private:
+  ConnectionVector connections;
+};
+
 class ModuleInstantiation : public StructuralStatement {
  public:
   std::string module_name;
@@ -487,16 +512,13 @@ class ModuleInstantiation : public StructuralStatement {
 
   std::string instance_name;
 
-  // map from instance port names to connection expression
   // NOTE: anonymous style of module connections is not supported
-  std::vector<std::pair<std::string, std::unique_ptr<Expression>>> connections;
+  std::unique_ptr<Connections> connections;
 
   // TODO Need to make sure that the instance parameters are a subset of the
   // module parameters
-  ModuleInstantiation(
-      std::string module_name, Parameters parameters, std::string instance_name,
-      std::vector<std::pair<std::string, std::unique_ptr<Expression>>>
-          connections)
+  ModuleInstantiation(std::string module_name, Parameters parameters,
+                      std::string instance_name, std::unique_ptr<Connections> connections)
       : module_name(module_name),
         parameters(std::move(parameters)),
         instance_name(instance_name),

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -186,7 +186,7 @@ std::unique_ptr<InlineVerilog> Transformer::visit(
 
 std::unique_ptr<ModuleInstantiation> Transformer::visit(
     std::unique_ptr<ModuleInstantiation> node) {
-  for (auto&& conn : node->connections) {
+  for (auto&& conn : *node->connections) {
     conn.second = this->visit(std::move(conn.second));
   }
   for (auto&& param : node->parameters) {

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -385,9 +385,9 @@ std::string ModuleInstantiation::toString() {
     module_inst_str += ")";
   }
   module_inst_str += " " + instance_name + "(";
-  if (!connections.empty()) {
+  if (!connections->empty()) {
     std::vector<std::string> param_strs;
-    for (auto &it : connections) {
+    for (auto &it : *connections) {
       param_strs.push_back("." + it.first + "(" + it.second->toString() + ")");
     }
     module_inst_str += join(param_strs, ", ");

--- a/tests/assign_inliner.cpp
+++ b/tests/assign_inliner.cpp
@@ -490,19 +490,19 @@ TEST(InlineAssignTests, TestInstConn) {
       std::make_unique<vAST::Identifier>("a")));
 
   vAST::Parameters parameters;
-  std::map<std::string, std::unique_ptr<vAST::Expression>> connections;
-  connections["c"] = vAST::make_id("a");
-  connections["i"] = vAST::make_id("x");
-  connections["o"] = vAST::make_id("y");
+  std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
+      connections;
+  connections.push_back(std::make_pair("c", vAST::make_id("a")));
+  connections.push_back(std::make_pair("i", vAST::make_id("x")));
+  connections.push_back(std::make_pair("o", vAST::make_id("y")));
 
   body.push_back(std::make_unique<vAST::ModuleInstantiation>(
-              "inner_module", std::move(parameters), "inner_module_inst",
-              std::move(connections)));
+      "inner_module", std::move(parameters), "inner_module_inst",
+      std::move(connections)));
 
   body.push_back(std::make_unique<vAST::ContinuousAssign>(
       std::make_unique<vAST::Identifier>("o"),
       std::make_unique<vAST::Identifier>("y")));
-
 
   std::unique_ptr<vAST::AbstractModule> module = std::make_unique<vAST::Module>(
       "test_module", std::move(ports), std::move(body));

--- a/tests/assign_inliner.cpp
+++ b/tests/assign_inliner.cpp
@@ -490,11 +490,10 @@ TEST(InlineAssignTests, TestInstConn) {
       std::make_unique<vAST::Identifier>("a")));
 
   vAST::Parameters parameters;
-  std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
-      connections;
-  connections.push_back(std::make_pair("c", vAST::make_id("a")));
-  connections.push_back(std::make_pair("i", vAST::make_id("x")));
-  connections.push_back(std::make_pair("o", vAST::make_id("y")));
+  std::unique_ptr<vAST::Connections> connections = std::make_unique<vAST::Connections>();
+  connections->insert("c", vAST::make_id("a"));
+  connections->insert("i", vAST::make_id("x"));
+  connections->insert("o", vAST::make_id("y"));
 
   body.push_back(std::make_unique<vAST::ModuleInstantiation>(
       "inner_module", std::move(parameters), "inner_module_inst",

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -11,14 +11,17 @@ vAST::Parameters make_simple_params() {
   return parameters;
 }
 
-std::map<std::string, std::unique_ptr<vAST::Expression>>
+std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
 make_simple_connections() {
-  std::map<std::string, std::unique_ptr<vAST::Expression>> connections;
-  connections["a"] = vAST::make_id("a");
-  connections["b"] =
-      std::make_unique<vAST::Index>(vAST::make_id("b"), vAST::make_num("0"));
-  connections["c"] = std::make_unique<vAST::Slice>(
-      vAST::make_id("c"), vAST::make_num("31"), vAST::make_num("0"));
+  std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
+      connections;
+  connections.push_back(std::make_pair("a", vAST::make_id("a")));
+  connections.push_back(std::make_pair(
+      "b",
+      std::make_unique<vAST::Index>(vAST::make_id("b"), vAST::make_num("0"))));
+  connections.push_back(std::make_pair(
+      "c", std::make_unique<vAST::Slice>(
+               vAST::make_id("c"), vAST::make_num("31"), vAST::make_num("0"))));
 
   return connections;
 }

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -11,17 +11,15 @@ vAST::Parameters make_simple_params() {
   return parameters;
 }
 
-std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
-make_simple_connections() {
-  std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
-      connections;
-  connections.push_back(std::make_pair("a", vAST::make_id("a")));
-  connections.push_back(std::make_pair(
+std::unique_ptr<vAST::Connections> make_simple_connections() {
+  std::unique_ptr<vAST::Connections> connections = std::make_unique<vAST::Connections>();
+  connections->insert("a", vAST::make_id("a"));
+  connections->insert(
       "b",
-      std::make_unique<vAST::Index>(vAST::make_id("b"), vAST::make_num("0"))));
-  connections.push_back(std::make_pair(
+      std::make_unique<vAST::Index>(vAST::make_id("b"), vAST::make_num("0")));
+  connections->insert(
       "c", std::make_unique<vAST::Slice>(
-               vAST::make_id("c"), vAST::make_num("31"), vAST::make_num("0"))));
+               vAST::make_id("c"), vAST::make_num("31"), vAST::make_num("0")));
 
   return connections;
 }


### PR DESCRIPTION
This changes the module instance logic to use a vector of pairs (port name, connection) to handle the port connections, rather than a map, so that the code generation uses insertion order rather than lexical order. CoreIR will need to be updated before this is merged.