### PR TITLE
Add blacklist to prevent inlining

### DIFF
--- a/include/verilogAST/assign_inliner.hpp
+++ b/include/verilogAST/assign_inliner.hpp
@@ -71,7 +71,7 @@ class AssignInliner : public Transformer {
 
  public:
   AssignInliner() : wire_blacklist() {};
-  AssignInliner(std::set<std::string> wire_blacklist) :
+  explicit AssignInliner(std::set<std::string> wire_blacklist) :
       wire_blacklist(wire_blacklist) {};
   using Transformer::visit;
   virtual std::unique_ptr<Expression> visit(std::unique_ptr<Expression> node);

--- a/include/verilogAST/assign_inliner.hpp
+++ b/include/verilogAST/assign_inliner.hpp
@@ -59,6 +59,7 @@ class AssignInliner : public Transformer {
   std::set<std::string> output_ports;
   std::set<std::string> input_ports;
   std::set<std::string> inlined_outputs;
+  std::set<std::string> wire_blacklist;
 
   std::vector<std::variant<std::unique_ptr<StructuralStatement>,
                            std::unique_ptr<Declaration>>>
@@ -66,7 +67,12 @@ class AssignInliner : public Transformer {
                                      std::unique_ptr<Declaration>>>
                 body);
 
+  bool can_inline(std::string key);
+
  public:
+  AssignInliner() : wire_blacklist() {};
+  AssignInliner(std::set<std::string> wire_blacklist) :
+      wire_blacklist(wire_blacklist) {};
   using Transformer::visit;
   virtual std::unique_ptr<Expression> visit(std::unique_ptr<Expression> node);
   virtual std::unique_ptr<ContinuousAssign> visit(

--- a/src/assign_inliner.cpp
+++ b/src/assign_inliner.cpp
@@ -58,8 +58,7 @@ bool AssignInliner::can_inline(std::string key) {
   if (this->wire_blacklist.count(key)) {
       return false;
   }
-  std::map<std::string, std::unique_ptr<Expression>>::iterator it =
-      assign_map.find(key);
+  auto it = assign_map.find(key);
   return it != assign_map.end() && (this->assign_count[key] == 1) &&
          (this->read_count[key] == 1 ||
           dynamic_cast<Identifier*>(it->second.get()) ||

--- a/tests/assign_inliner.cpp
+++ b/tests/assign_inliner.cpp
@@ -66,7 +66,25 @@ TEST(InlineAssignTests, TestBasic) {
 
   EXPECT_EQ(module->toString(), raw_str);
 
+  std::set<std::string> blacklist = {"x", "x_vec"};
+  vAST::AssignInliner transformer_blacklist(blacklist);
+  module = transformer_blacklist.visit(std::move(module));
+  EXPECT_EQ(module->toString(), raw_str);
+
   std::string expected_str =
+      "module test_module (input i, output o, output [1:0] o_vec);\n"
+      "wire [1:0] x_vec;\n"
+      "assign o = i;\n"
+      "assign x_vec = {i,i};\n"
+      "assign o_vec = x_vec;\n"
+      "endmodule\n";
+
+  blacklist = {"x_vec"};
+  vAST::AssignInliner transformer_blacklist2(blacklist);
+  module = transformer_blacklist2.visit(std::move(module));
+  EXPECT_EQ(module->toString(), expected_str);
+
+  expected_str =
       "module test_module (input i, output o, output [1:0] o_vec);\n"
       "assign o = i;\n"
       "assign o_vec = {i,i};\n"


### PR DESCRIPTION
Enables the user to prevent a wire from being inlined.  Will be used by coreir to preserve intermediate wires.