### PR TITLE
Add ConcatCoalescer transformer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/include/
 ) 
 
-set(LIB_SOURCES src/verilogAST.cpp src/transformer.cpp src/assign_inliner.cpp)
+set(LIB_SOURCES src/verilogAST.cpp src/transformer.cpp src/assign_inliner.cpp
+    src/concat_coalescer.cpp)
 
 set(LIBRARY_NAME verilogAST)
 add_library(${LIBRARY_NAME} SHARED ${LIB_SOURCES})
@@ -65,6 +66,10 @@ if (VERILOGAST_BUILD_TESTS)
     add_executable(assign_inliner tests/assign_inliner.cpp)
     target_link_libraries(assign_inliner gtest_main ${LIBRARY_NAME})
     add_test(NAME assign_inliner_tests COMMAND assign_inliner)
+
+    add_executable(concat_coalescer tests/concat_coalescer.cpp)
+    target_link_libraries(concat_coalescer gtest_main ${LIBRARY_NAME})
+    add_test(NAME concat_coalescer_tests COMMAND concat_coalescer)
 endif()
 
 install(TARGETS ${LIBRARY_NAME} DESTINATION lib)

--- a/include/verilogAST/concat_coalescer.hpp
+++ b/include/verilogAST/concat_coalescer.hpp
@@ -1,0 +1,18 @@
+#ifndef VERILOGAST_ASSIGN_INLINER_H
+#define VERILOGAST_ASSIGN_INLINER_H
+
+#include "verilogAST.hpp"
+#include "verilogAST/transformer.hpp"
+
+namespace verilogAST {
+
+class ConcatCoalescer : public Transformer {
+ public:
+  using Transformer::visit;
+
+  std::unique_ptr<Expression> visit(std::unique_ptr<Expression> node) override;
+};
+
+}  // namespace verilogAST
+
+#endif  // VERILOGAST_ASSIGN_INLINER_H

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -4,10 +4,71 @@ namespace verilogAST {
 
 namespace {
 
-std::pair<bool, int> get_index_integer(const Expression* expr) {
+struct Run {
+  std::string name;
+  int first;  // inclusive
+  int last;  // inclusive
+};
+
+class RunOrExpr {
+ public:
+  explicit RunOrExpr(const Expression* expr) : run_(), expr_(expr) {}
+  explicit RunOrExpr(std::string name, int first, int last)
+      : run_({name, first, last}), expr_(nullptr) {}
+
+  bool isRun() const { return expr_ == nullptr; }
+
+  // Tries to merge in @other into this run if it is contiguous. Returns true if
+  // merged, falses otherwise.
+  bool tryMerge(const RunOrExpr& other) {
+    if (!isRun() or !other.isRun()) return false;
+    if (run_.name != other.run_.name) return false;
+    if (run_.last != other.run_.first + 1) return false;
+    run_.last = other.run_.first;
+    return true;
+  }
+
+  // Returns the expression corresponding to this run. If this is not a run,
+  // then we return a clone of the contained expression. Otherwise, we return an
+  // Index expresssion if the run contains only one index, or a Slice if it
+  // contains > 1.
+  std::unique_ptr<Expression> generateExpression() const {
+    if (not isRun()) return expr_->clone();
+    auto first = std::unique_ptr<Expression>(
+        new NumericLiteral(std::to_string(run_.first)));
+    if (run_.first == run_.last) {
+      return std::unique_ptr<Expression>(
+          new Index(std::make_unique<Identifier>(run_.name), std::move(first)));
+    }
+    auto id = std::unique_ptr<Expression>(new Identifier(run_.name));
+    auto last = std::unique_ptr<Expression>(
+        new NumericLiteral(std::to_string(run_.last)));
+    return std::unique_ptr<Expression>(
+        new Slice(std::move(id), std::move(first), std::move(last)));
+  }
+
+ private:
+  Run run_;
+  const Expression* expr_ = nullptr;
+};
+
+// Tries to extract a NumericLiteral (int) from @expr. Returns a pair of <true,
+// value> if successful; otherwise, returns <false, 0>.
+std::pair<bool, int> expr_to_int(const Expression* expr) {
   auto ptr = dynamic_cast<const NumericLiteral*>(expr);
   if (not ptr) return std::make_pair(false, 0);
   return std::make_pair(true, std::atoi(ptr->value.c_str()));
+}
+
+// Consumes a Concat node argument @arg and tries to make a run out of it. If it
+// is of the form Index(Identifier name, NumericLiteral val) then we return
+// RunOrExpr(name, val, val); otherwise we return RunOrExpr(arg).
+RunOrExpr makeRunOrExpr(const Expression* arg) {
+  auto index = dynamic_cast<const Index*>(arg);
+  if (not index) return RunOrExpr(arg);
+  auto as_int = expr_to_int(index->index.get());
+  if (not as_int.first) return RunOrExpr(arg);
+  return RunOrExpr(index->id->value, as_int.second, as_int.second);
 }
 
 }  // namespace
@@ -15,29 +76,26 @@ std::pair<bool, int> get_index_integer(const Expression* expr) {
 std::unique_ptr<Expression> ConcatCoalescer::visit(
     std::unique_ptr<Expression> node) {
   auto ptr = dynamic_cast<const Concat*>(node.get());
-  if (not ptr) return node;
-  const Index* first = nullptr;
-  const Index* last = nullptr;
-  int last_index = 0;
+  // This pass only operates on non-empty Concat nodes.
+  if (not ptr or ptr->args.size() == 0) return node;
+  std::vector<RunOrExpr> runs;
   for (const auto& arg : ptr->args) {
-    auto curr = dynamic_cast<const Index*>(arg.get());
-    if (not curr) return node;
-    const auto as_int = get_index_integer(curr->index.get());
-    if (not as_int.first) return node;
-    if (not first) {
-      first = curr;
-      last = curr;
-      last_index = as_int.second;
-      continue;
+    auto run_or_expr = makeRunOrExpr(arg.get());
+    // If this is the first run, then we append it. Otherwise, we try to merge
+    // it into the previous run. If it cannot be merged, then we append it.
+    if (runs.size() == 0 or not runs.back().tryMerge(run_or_expr)) {
+      runs.push_back(run_or_expr);
     }
-    if (curr->id->value != last->id->value) return node;
-    if (as_int.second != last_index - 1) return node;
-    last_index = as_int.second;
-    last = curr;
   }
-  return std::make_unique<Slice>(first->id->clone(),
-                                 first->index->clone(),
-                                 last->index->clone());
+  assert(runs.size() > 0);
+  // If there is sonly one run, then we return that run as a standalone
+  // expression; otherwise, we return a Concat node containing the runs.
+  if (runs.size() == 1) return runs.front().generateExpression();
+  std::vector<std::unique_ptr<Expression>> args;
+  for (const auto& run : runs) {
+    args.push_back(run.generateExpression());
+  }
+  return std::make_unique<Concat>(std::move(args));
 }
 
 }  // namespace verilogAST

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -1,0 +1,45 @@
+#include "verilogAST/concat_coalescer.hpp"
+
+namespace verilogAST {
+
+namespace {
+
+std::pair<bool, int> get_index_integer(const Expression* expr) {
+  auto ptr = dynamic_cast<const NumericLiteral*>(expr);
+  if (not ptr) return std::make_pair(false, 0);
+  return std::make_pair(true, std::atoi(ptr->value.c_str()));
+}
+
+}  // namespace
+
+std::unique_ptr<Expression> ConcatCoalescer::visit(
+    std::unique_ptr<Expression> node) {
+  auto ptr = dynamic_cast<Concat*>(node.get());
+  if (not ptr) return node;
+  Index* first = nullptr;
+  Index* last = nullptr;
+  int first_index = 0;
+  int last_index = 0;
+  for (const auto& arg : ptr->args) {
+    auto curr = dynamic_cast<Index*>(arg.get());
+    if (not curr) return node;
+    const auto as_int = get_index_integer(curr->index.get());
+    if (not as_int.first) return node;
+    if (not first) {
+      first = curr;
+      last = curr;
+      first_index = as_int.second;
+      last_index = as_int.second;
+      continue;
+    }
+    if (curr->id->value != last->id->value) return node;
+    if (as_int.second != last_index - 1) return node;
+    last_index = as_int.second;
+    last = curr;
+  }
+  return std::make_unique<Slice>(first->id->clone(),
+                                 first->index->clone(),
+                                 last->index->clone());
+}
+
+}  // namespace verilogAST

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include "verilogAST/concat_coalescer.hpp"
 
 namespace verilogAST {

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -14,14 +14,14 @@ std::pair<bool, int> get_index_integer(const Expression* expr) {
 
 std::unique_ptr<Expression> ConcatCoalescer::visit(
     std::unique_ptr<Expression> node) {
-  auto ptr = dynamic_cast<Concat*>(node.get());
+  auto ptr = dynamic_cast<const Concat*>(node.get());
   if (not ptr) return node;
-  Index* first = nullptr;
-  Index* last = nullptr;
+  const Index* first = nullptr;
+  const Index* last = nullptr;
   int first_index = 0;
   int last_index = 0;
   for (const auto& arg : ptr->args) {
-    auto curr = dynamic_cast<Index*>(arg.get());
+    auto curr = dynamic_cast<const Index*>(arg.get());
     if (not curr) return node;
     const auto as_int = get_index_integer(curr->index.get());
     if (not as_int.first) return node;

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -18,7 +18,6 @@ std::unique_ptr<Expression> ConcatCoalescer::visit(
   if (not ptr) return node;
   const Index* first = nullptr;
   const Index* last = nullptr;
-  int first_index = 0;
   int last_index = 0;
   for (const auto& arg : ptr->args) {
     auto curr = dynamic_cast<const Index*>(arg.get());
@@ -28,7 +27,6 @@ std::unique_ptr<Expression> ConcatCoalescer::visit(
     if (not first) {
       first = curr;
       last = curr;
-      first_index = as_int.second;
       last_index = as_int.second;
       continue;
     }

--- a/tests/concat_coalescer.cpp
+++ b/tests/concat_coalescer.cpp
@@ -122,8 +122,63 @@ TEST(ConcatCoalescerTests, ReverseRun) {
       ");\n"
       "assign O = {I[4],I[5],I[6],I[7],I[3:0]};\n"
       "endmodule\n";
-  // Sequence has no contiguous runs.
   runTest({0, 1, 2, 3, 7, 6, 5, 4}, pre, post);
+}
+
+TEST(ConcatCoalescerTests, MultipleNames) {
+  auto pre =
+      "module test_module (\n"
+      "    input [7:0] I0,\n"
+      "    input [7:0] I1,\n"
+      "    output [7:0] O\n"
+      ");\n"
+      "assign O = {I0[7],I0[6],I0[5],I0[4],I1[3],I1[2],I1[1],I1[0]};\n"
+      "endmodule\n";
+  auto post =
+      "module test_module (\n"
+      "    input [7:0] I0,\n"
+      "    input [7:0] I1,\n"
+      "    output [7:0] O\n"
+      ");\n"
+      "assign O = {I0[7:4],I1[3:0]};\n"
+      "endmodule\n";
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::make_unique<vAST::Port>(makeVector("I0", 7, 0),
+                                               vAST::INPUT,
+                                               vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(makeVector("I1", 7, 0),
+                                               vAST::INPUT,
+                                               vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(makeVector("O", 7, 0),
+                                               vAST::OUTPUT,
+                                               vAST::WIRE));
+  std::vector<BodyElement> body;
+
+  std::vector<std::unique_ptr<vAST::Expression>> args = {};
+  for (int i = 7; i >= 0; i--) {
+    auto id = i > 3 ? "I0" : "I1";
+    args.emplace_back(
+        new vAST::Index(
+            vAST::make_id(id),
+            vAST::make_num(std::to_string(i))));
+  }
+  std::unique_ptr<vAST::Expression> rhs(new vAST::Concat(std::move(args)));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(
+      std::make_unique<vAST::Identifier>("O"), std::move(rhs)));
+
+  std::unique_ptr<vAST::AbstractModule> module = std::make_unique<vAST::Module>(
+      "test_module",
+      std::move(ports),
+      std::move(body));
+
+  EXPECT_EQ(module->toString(), pre);
+
+  // Run ConcatCoalescer transformer.
+  vAST::ConcatCoalescer transformer;
+  module = transformer.visit(std::move(module));
+
+  EXPECT_EQ(module->toString(), post);
 }
 
 }  // namespace

--- a/tests/concat_coalescer.cpp
+++ b/tests/concat_coalescer.cpp
@@ -1,0 +1,87 @@
+#include "verilogAST/concat_coalescer.hpp"
+#include "common.cpp"
+#include "gtest/gtest.h"
+
+namespace vAST = verilogAST;
+
+namespace {
+
+using BodyElement = std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                                 std::unique_ptr<vAST::Declaration>>;
+
+
+auto makeVector(std::string name, int hi, int lo) {
+  return std::make_unique<vAST::Vector>(vAST::make_id(name),
+                                        vAST::make_num(std::to_string(hi)),
+                                        vAST::make_num(std::to_string(lo)));
+}
+
+TEST(ConcatCoalescerTests, TestBasic) {
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::make_unique<vAST::Port>(makeVector("I", 7, 0),
+                                               vAST::INPUT,
+                                               vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(makeVector("O0", 3, 0),
+                                               vAST::OUTPUT,
+                                               vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(makeVector("O1", 3, 0),
+                                               vAST::OUTPUT,
+                                               vAST::WIRE));
+  std::vector<BodyElement> body;
+
+  std::vector<std::unique_ptr<vAST::Expression>> args0 = {};
+  std::vector<std::unique_ptr<vAST::Expression>> args1 = {};
+  for (int i = 3; i >= 0; i--) {
+    args0.emplace_back(new vAST::Index(vAST::make_id("I"),
+                                       vAST::make_num(std::to_string(i))));
+    args1.emplace_back(new vAST::Index(vAST::make_id("I"),
+                                       vAST::make_num(std::to_string(i + 4))));
+  }
+  std::unique_ptr<vAST::Expression> rhs0(new vAST::Concat(std::move(args0)));
+  std::unique_ptr<vAST::Expression> rhs1(new vAST::Concat(std::move(args1)));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(
+      std::make_unique<vAST::Identifier>("O0"), std::move(rhs0)));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(
+      std::make_unique<vAST::Identifier>("O1"), std::move(rhs1)));
+
+  std::unique_ptr<vAST::AbstractModule> module = std::make_unique<vAST::Module>(
+      "test_module",
+      std::move(ports),
+      std::move(body));
+
+  std::string expected;
+
+  expected =
+      "module test_module (\n"
+      "    input [7:0] I,\n"
+      "    output [3:0] O0,\n"
+      "    output [3:0] O1\n"
+      ");\n"
+      "assign O0 = {I[3],I[2],I[1],I[0]};\n"
+      "assign O1 = {I[7],I[6],I[5],I[4]};\n"
+      "endmodule\n";
+  EXPECT_EQ(module->toString(), expected);
+
+  // Run ConcatCoalescer transformer.
+  vAST::ConcatCoalescer transformer;
+  module = transformer.visit(std::move(module));
+  expected =
+      "module test_module (\n"
+      "    input [7:0] I,\n"
+      "    output [3:0] O0,\n"
+      "    output [3:0] O1\n"
+      ");\n"
+      "assign O0 = I[3:0];\n"
+      "assign O1 = I[7:4];\n"
+      "endmodule\n";
+  EXPECT_EQ(module->toString(), expected);
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/concat_coalescer.cpp
+++ b/tests/concat_coalescer.cpp
@@ -106,6 +106,26 @@ TEST(ConcatCoalescerTests, TestNoRuns) {
   runTest({0, 2, 4, 6, 1, 3, 5, 7}, pre, post);
 }
 
+TEST(ConcatCoalescerTests, ReverseRun) {
+  auto pre =
+      "module test_module (\n"
+      "    input [7:0] I,\n"
+      "    output [7:0] O\n"
+      ");\n"
+      "assign O = {I[4],I[5],I[6],I[7],I[3],I[2],I[1],I[0]};\n"
+      "endmodule\n";
+  // ConcatCoalescer doesn't coalese reverse runs right now.
+  auto post =
+      "module test_module (\n"
+      "    input [7:0] I,\n"
+      "    output [7:0] O\n"
+      ");\n"
+      "assign O = {I[4],I[5],I[6],I[7],I[3:0]};\n"
+      "endmodule\n";
+  // Sequence has no contiguous runs.
+  runTest({0, 1, 2, 3, 7, 6, 5, 4}, pre, post);
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
First pass at adding a pass to make `{x[n], x[n - 1], ..., x[k]}` look like `x[n:k]`. The transformation right now only looks for fully contiguous concat args. We could have other cases like multiple contiguous runs, etc., but that support can easily be added to this pass and I think this covers the most useful case. 