### PR TITLE
Add attribute node

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -125,6 +125,7 @@ class Attribute : public Expression {
           value,
       std::string attr)
       : value(std::move(value)), attr(attr){};
+
   Attribute(const Attribute& rhs)
       : value(std::visit(
             [](auto&& value) -> std::variant<std::unique_ptr<Identifier>,
@@ -133,6 +134,7 @@ class Attribute : public Expression {
             },
             rhs.value)),
         attr(rhs.attr){};
+
   std::unique_ptr<Attribute> clone() const {
     return std::unique_ptr<Attribute>(clone_impl());
   }

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -159,7 +159,7 @@ class Index : public Expression {
   std::unique_ptr<Identifier> id;
   std::unique_ptr<Expression> index;
 
-  Index(std::unique_ptr<Expression> id, std::unique_ptr<Expression> index)
+  Index(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> index)
       : id(std::move(id)), index(std::move(index)){};
 
   Index(const Index& rhs) : id(rhs.id->clone()), index(rhs.index->clone()){};

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -110,6 +110,30 @@ class Identifier : public Expression {
   ~Identifier(){};
 };
 
+class Attribute : public Expression {
+ protected:
+  virtual Attribute* clone_impl() const override {
+    return new Attribute(*this);
+  };
+
+ public:
+  std::unique_ptr<Expression> value;
+  std::string attr;
+
+  Attribute(std::unique_ptr<Expression> value, std::string attr)
+      : value(std::move(value)), attr(attr){};
+  Attribute(const Attribute& rhs)
+      : value(rhs.value->clone()), attr(rhs.attr){};
+  auto clone() const { return std::unique_ptr<Attribute>(clone_impl()); }
+
+  bool operator==(const Attribute& rhs) {
+    return (this->value == rhs.value && this->attr == rhs.attr);
+  }
+
+  std::string toString() override;
+  ~Attribute(){};
+};
+
 class String : public Expression {
  protected:
   virtual String* clone_impl() const override { return new String(*this); };
@@ -128,17 +152,17 @@ class String : public Expression {
 class Index : public Expression {
  protected:
   virtual Index* clone_impl() const override {
-    return new Index(this->id->clone(), this->index->clone());
+    return new Index(this->value->clone(), this->index->clone());
   };
 
  public:
-  std::unique_ptr<Identifier> id;
+  std::unique_ptr<Expression> value;
   std::unique_ptr<Expression> index;
 
-  Index(std::unique_ptr<Identifier> id, std::unique_ptr<Expression> index)
-      : id(std::move(id)), index(std::move(index)){};
+  Index(std::unique_ptr<Expression> value, std::unique_ptr<Expression> index)
+      : value(std::move(value)), index(std::move(index)){};
 
-  Index(const Index& rhs) : id(rhs.id->clone()), index(rhs.index->clone()){};
+  Index(const Index& rhs) : value(rhs.value->clone()), index(rhs.index->clone()){};
 
   std::string toString() override;
   ~Index(){};

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -152,17 +152,17 @@ class String : public Expression {
 class Index : public Expression {
  protected:
   virtual Index* clone_impl() const override {
-    return new Index(this->value->clone(), this->index->clone());
+    return new Index(this->id->clone(), this->index->clone());
   };
 
  public:
-  std::unique_ptr<Expression> value;
+  std::unique_ptr<Identifier> id;
   std::unique_ptr<Expression> index;
 
-  Index(std::unique_ptr<Expression> value, std::unique_ptr<Expression> index)
-      : value(std::move(value)), index(std::move(index)){};
+  Index(std::unique_ptr<Expression> id, std::unique_ptr<Expression> index)
+      : id(std::move(id)), index(std::move(index)){};
 
-  Index(const Index& rhs) : value(rhs.value->clone()), index(rhs.index->clone()){};
+  Index(const Index& rhs) : id(rhs.id->clone()), index(rhs.index->clone()){};
 
   std::string toString() override;
   ~Index(){};

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -117,14 +117,25 @@ class Attribute : public Expression {
   };
 
  public:
-  std::unique_ptr<Expression> value;
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>> value;
   std::string attr;
 
-  Attribute(std::unique_ptr<Expression> value, std::string attr)
+  Attribute(
+      std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>>
+          value,
+      std::string attr)
       : value(std::move(value)), attr(attr){};
   Attribute(const Attribute& rhs)
-      : value(rhs.value->clone()), attr(rhs.attr){};
-  auto clone() const { return std::unique_ptr<Attribute>(clone_impl()); }
+      : value(std::visit(
+            [](auto&& value) -> std::variant<std::unique_ptr<Identifier>,
+                                             std::unique_ptr<Attribute>> {
+              return value->clone();
+            },
+            rhs.value)),
+        attr(rhs.attr){};
+  std::unique_ptr<Attribute> clone() const {
+    return std::unique_ptr<Attribute>(clone_impl());
+  }
 
   bool operator==(const Attribute& rhs) {
     return (this->value == rhs.value && this->attr == rhs.attr);

--- a/include/verilogAST/transformer.hpp
+++ b/include/verilogAST/transformer.hpp
@@ -20,6 +20,8 @@ class Transformer {
 
   virtual std::unique_ptr<Identifier> visit(std::unique_ptr<Identifier> node);
 
+  virtual std::unique_ptr<Attribute> visit(std::unique_ptr<Attribute> node);
+
   virtual std::unique_ptr<String> visit(std::unique_ptr<String> node);
 
   virtual std::unique_ptr<Index> visit(std::unique_ptr<Index> node);

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -69,7 +69,9 @@ RunOrExpr makeRunOrExpr(const Expression* arg) {
   if (not index) return RunOrExpr(arg);
   auto as_int = expr_to_int(index->index.get());
   if (not as_int.first) return RunOrExpr(arg);
-  return RunOrExpr(index->id->value, as_int.second, as_int.second);
+  auto index_id = dynamic_cast<const Identifier*>(index->value.get());
+  if (not index_id) return RunOrExpr(arg);
+  return RunOrExpr(index_id->value, as_int.second, as_int.second);
 }
 
 }  // namespace

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -69,9 +69,7 @@ RunOrExpr makeRunOrExpr(const Expression* arg) {
   if (not index) return RunOrExpr(arg);
   auto as_int = expr_to_int(index->index.get());
   if (not as_int.first) return RunOrExpr(arg);
-  auto index_id = dynamic_cast<const Identifier*>(index->value.get());
-  if (not index_id) return RunOrExpr(arg);
-  return RunOrExpr(index_id->value, as_int.second, as_int.second);
+  return RunOrExpr(index->id->value, as_int.second, as_int.second);
 }
 
 }  // namespace

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<String> Transformer::visit(std::unique_ptr<String> node) {
 }
 
 std::unique_ptr<Index> Transformer::visit(std::unique_ptr<Index> node) {
-  node->value = this->visit(std::move(node->value));
+  node->id = this->visit(std::move(node->id));
   node->index = this->visit(std::move(node->index));
   return node;
 }

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -13,6 +13,10 @@ std::unique_ptr<Expression> Transformer::visit(
     node.release();
     return this->visit(std::unique_ptr<Identifier>(ptr));
   }
+  if (auto ptr = dynamic_cast<Attribute*>(node.get())) {
+    node.release();
+    return this->visit(std::unique_ptr<Attribute>(ptr));
+  }
   if (auto ptr = dynamic_cast<String*>(node.get())) {
     node.release();
     return this->visit(std::unique_ptr<String>(ptr));
@@ -63,12 +67,18 @@ std::unique_ptr<Identifier> Transformer::visit(
   return node;
 }
 
+std::unique_ptr<Attribute> Transformer::visit(
+    std::unique_ptr<Attribute> node) {
+  node->value = this->visit(std::move(node->value));
+  return node;
+}
+
 std::unique_ptr<String> Transformer::visit(std::unique_ptr<String> node) {
   return node;
 }
 
 std::unique_ptr<Index> Transformer::visit(std::unique_ptr<Index> node) {
-  node->id = this->visit(std::move(node->id));
+  node->value = this->visit(std::move(node->value));
   node->index = this->visit(std::move(node->index));
   return node;
 }

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -3,6 +3,12 @@
 #include <regex>
 #include <unordered_set>
 
+template <typename... Ts>
+std::string variant_to_string(std::variant<Ts...> &value) {
+  return std::visit(
+      [](auto &&value) -> std::string { return value->toString(); }, value);
+}
+
 // Helper function to join a vector of strings with a specified separator ala
 // Python's ",".join(...)
 std::string join(std::vector<std::string> vec, std::string separator) {
@@ -117,7 +123,7 @@ std::string Identifier::toString() {
 }
 
 std::string Attribute::toString() {
-  return this->value->toString() + "." + this->attr;
+  return variant_to_string(this->value) + "." + this->attr;
 }
 
 std::string String::toString() { return "\"" + value + "\""; }
@@ -277,12 +283,6 @@ std::string Call::toString() {
     arg_strs.push_back(arg->toString());
   }
   return func + "(" + join(arg_strs, ", ") + ")";
-}
-
-template <typename... Ts>
-std::string variant_to_string(std::variant<Ts...> &value) {
-  return std::visit(
-      [](auto &&value) -> std::string { return value->toString(); }, value);
 }
 
 std::string Port::toString() {

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -123,8 +123,7 @@ std::string Attribute::toString() {
 std::string String::toString() { return "\"" + value + "\""; }
 
 std::string Index::toString() {
-  std::string expr_str = expr_to_string_with_parens(value);
-  return expr_str + '[' + index->toString() + ']';
+  return return id->toString() + '[' + index->toString() + ']';
 }
 
 std::string Slice::toString() {

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -123,7 +123,7 @@ std::string Attribute::toString() {
 std::string String::toString() { return "\"" + value + "\""; }
 
 std::string Index::toString() {
-  return return id->toString() + '[' + index->toString() + ']';
+  return id->toString() + '[' + index->toString() + ']';
 }
 
 std::string Slice::toString() {

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -101,10 +101,21 @@ std::string Identifier::toString() {
     return value;
 }
 
+std::string Attribute::toString() {
+  return this->value->toString() + "." + this->attr;
+}
+
 std::string String::toString() { return "\"" + value + "\""; }
 
 std::string Index::toString() {
-  return id->toString() + '[' + index->toString() + ']';
+  std::string expr_str = value->toString();
+  if (dynamic_cast<Identifier *>(value.get())) {
+  } else if (dynamic_cast<Index *>(value.get())) {
+  } else if (dynamic_cast<Slice *>(value.get())) {
+  } else {
+    expr_str = "(" + expr_str + ")";
+  }
+  return expr_str + '[' + index->toString() + ']';
 }
 
 std::string Slice::toString() {

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -15,6 +15,21 @@ std::string join(std::vector<std::string> vec, std::string separator) {
 }
 
 namespace verilogAST {
+
+std::string expr_to_string_with_parens(std::unique_ptr<Expression> &expr) {
+  // FIXME: For now we just do naive precedence logic
+  std::string expr_str = expr->toString();
+  if (dynamic_cast<Identifier *>(expr.get())) {
+  } else if (dynamic_cast<NumericLiteral *>(expr.get())) {
+  } else if (dynamic_cast<Index *>(expr.get())) {
+  } else if (dynamic_cast<Slice *>(expr.get())) {
+  } else if (dynamic_cast<Attribute *>(expr.get())) {
+  } else {
+    expr_str = "(" + expr_str + ")";
+  }
+  return expr_str;
+}
+
 std::string NumericLiteral::toString() {
   std::string signed_str = _signed ? "s" : "";
 
@@ -108,24 +123,12 @@ std::string Attribute::toString() {
 std::string String::toString() { return "\"" + value + "\""; }
 
 std::string Index::toString() {
-  std::string expr_str = value->toString();
-  if (dynamic_cast<Identifier *>(value.get())) {
-  } else if (dynamic_cast<Index *>(value.get())) {
-  } else if (dynamic_cast<Slice *>(value.get())) {
-  } else {
-    expr_str = "(" + expr_str + ")";
-  }
+  std::string expr_str = expr_to_string_with_parens(value);
   return expr_str + '[' + index->toString() + ']';
 }
 
 std::string Slice::toString() {
-  std::string expr_str = expr->toString();
-  if (dynamic_cast<Identifier *>(expr.get())) {
-  } else if (dynamic_cast<Index *>(expr.get())) {
-  } else if (dynamic_cast<Slice *>(expr.get())) {
-  } else {
-    expr_str = "(" + expr_str + ")";
-  }
+  std::string expr_str = expr_to_string_with_parens(expr);
   return expr_str + '[' + high_index->toString() + ':' + low_index->toString() +
          ']';
 }
@@ -201,23 +204,8 @@ std::string BinaryOp::toString() {
       op_str = ">=";
       break;
   }
-  std::string lstr = left->toString();
-  std::string rstr = right->toString();
-  // TODO Precedence logic, for now we just insert parens if not symbol or num
-  if (dynamic_cast<Identifier *>(left.get())) {
-  } else if (dynamic_cast<NumericLiteral *>(left.get())) {
-  } else if (dynamic_cast<Index *>(left.get())) {
-  } else if (dynamic_cast<Slice *>(left.get())) {
-  } else {
-    lstr = "(" + lstr + ")";
-  }
-  if (dynamic_cast<Identifier *>(right.get())) {
-  } else if (dynamic_cast<NumericLiteral *>(right.get())) {
-  } else if (dynamic_cast<Index *>(right.get())) {
-  } else if (dynamic_cast<Slice *>(right.get())) {
-  } else {
-    rstr = "(" + rstr + ")";
-  }
+  std::string lstr = expr_to_string_with_parens(left);
+  std::string rstr = expr_to_string_with_parens(right);
   return lstr + ' ' + op_str + ' ' + rstr;
 }
 
@@ -258,15 +246,7 @@ std::string UnaryOp::toString() {
       op_str = "-";
       break;
   }
-  std::string operand_str = operand->toString();
-  // TODO Precedence logic, for now we just insert parens if not symbol or num
-  if (dynamic_cast<Identifier *>(operand.get())) {
-  } else if (dynamic_cast<NumericLiteral *>(operand.get())) {
-  } else if (dynamic_cast<Index *>(operand.get())) {
-  } else if (dynamic_cast<Slice *>(operand.get())) {
-  } else {
-    operand_str = "(" + operand_str + ")";
-  }
+  std::string operand_str = expr_to_string_with_parens(operand);
   return op_str + ' ' + operand_str;
 }
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -574,7 +574,7 @@ TEST(BasicTests, TestIndexCopy) {
   std::unique_ptr<vAST::Index> x1 = std::make_unique<vAST::Index>(*x);
   EXPECT_EQ(x->toString(), "x[y]");
   EXPECT_EQ(x1->toString(), "x[y]");
-  x1->value = vAST::make_id("z");
+  x1->id->value = "z";
   x1->index = std::make_unique<vAST::Identifier>("a");
   EXPECT_EQ(x->toString(), "x[y]");
   EXPECT_EQ(x1->toString(), "z[a]");

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -66,11 +66,6 @@ TEST(BasicTests, TestString) {
 TEST(BasicTests, TestIndex) {
   vAST::Index index(vAST::make_id("x"), vAST::make_num("0"));
   EXPECT_EQ(index.toString(), "x[0]");
-
-  std::unique_ptr<vAST::BinaryOp> binop = std::make_unique<vAST::BinaryOp>(
-      vAST::make_id("x"), vAST::BinOp::ADD, vAST::make_id("y"));
-  vAST::Index index_expr(std::move(binop), vAST::make_num("0"));
-  EXPECT_EQ(index_expr.toString(), "(x + y)[0]");
 }
 
 TEST(BasicTests, TestSlice) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -40,6 +40,14 @@ TEST(BasicTests, TestIdentifier) {
   EXPECT_EQ(id.toString(), "x");
 }
 
+TEST(BasicTests, TestAttribute) {
+  vAST::Attribute attr(vAST::make_id("x"), "y");
+  EXPECT_EQ(attr.toString(), "x.y");
+  vAST::Attribute attr2(
+      std::make_unique<vAST::Attribute>(vAST::make_id("a"), "b"), "c");
+  EXPECT_EQ(attr2.toString(), "a.b.c");
+}
+
 TEST(BasicTests, TestIdentifierEscaped) {
   vAST::Identifier id("instance[5]");
   EXPECT_EQ(id.toString(), "\\instance[5] ");
@@ -58,6 +66,11 @@ TEST(BasicTests, TestString) {
 TEST(BasicTests, TestIndex) {
   vAST::Index index(vAST::make_id("x"), vAST::make_num("0"));
   EXPECT_EQ(index.toString(), "x[0]");
+
+  std::unique_ptr<vAST::BinaryOp> binop = std::make_unique<vAST::BinaryOp>(
+      vAST::make_id("x"), vAST::BinOp::ADD, vAST::make_id("y"));
+  vAST::Index index_expr(std::move(binop), vAST::make_num("0"));
+  EXPECT_EQ(index_expr.toString(), "(x + y)[0]");
 }
 
 TEST(BasicTests, TestSlice) {
@@ -561,7 +574,7 @@ TEST(BasicTests, TestIndexCopy) {
   std::unique_ptr<vAST::Index> x1 = std::make_unique<vAST::Index>(*x);
   EXPECT_EQ(x->toString(), "x[y]");
   EXPECT_EQ(x1->toString(), "x[y]");
-  x1->id->value = "z";
+  x1->value = vAST::make_id("z");
   x1->index = std::make_unique<vAST::Identifier>("a");
   EXPECT_EQ(x->toString(), "x[y]");
   EXPECT_EQ(x1->toString(), "z[a]");

--- a/tests/transformer.cpp
+++ b/tests/transformer.cpp
@@ -85,8 +85,9 @@ TEST(TransformerTests, TestXtoZ) {
   call_args.push_back(std::make_unique<vAST::TernaryOp>(
       std::make_unique<vAST::Concat>(std::move(concat_args)),
       vAST::make_binop(
-          std::make_unique<vAST::Slice>(vAST::make_id("x"), vAST::make_num("3"),
-                                        vAST::make_num("1")),
+          std::make_unique<vAST::Slice>(
+              std::make_unique<vAST::Attribute>(vAST::make_id("x"), "j"),
+              vAST::make_num("3"), vAST::make_num("1")),
           vAST::BinOp::ADD,
           std::make_unique<vAST::UnaryOp>(
               std::make_unique<vAST::Index>(vAST::make_id("y"),
@@ -99,7 +100,7 @@ TEST(TransformerTests, TestXtoZ) {
       std::make_unique<vAST::CallExpr>("my_func", std::move(call_args));
   XtoZ transformer;
   EXPECT_EQ(transformer.visit(std::move(expr))->toString(),
-            "my_func({z,b} ? z[3:1] + (~ y[1]) : {(2){z}}, z)");
+            "my_func({z,b} ? z.j[3:1] + (~ y[1]) : {(2){z}}, z)");
 }
 TEST(TransformerTests, TestReplaceNameWithExpr) {
   std::unique_ptr<vAST::Expression> expr = vAST::make_binop(


### PR DESCRIPTION
This adds support for Verilog's hierarchical select syntax (inst0.inst1.O) and also generalized the index node to work with arbitrary expressions (rather than just ids), so you can do something like `(x + y)[0]`