### PR TITLE
Add interpolated_symbols logic to inline verilog

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -503,11 +503,22 @@ class InlineVerilog : public StructuralStatement {
   // statement(s) in the body of a module definition.  The contents of
   // `value` must be a valid verilog statement inside a module body.  The
   // contents are not validated.
+  //
+  // interpolated_symbols provides a mapping of the form "symbol": expression
+  // where instances of the pattern {symbol} will be replaced by
+  // expression->toString()  This can be used to inline symbols into the
+  // verilog that may be changed by a transformer, e.g. wire inlining
  public:
   std::string value;
+  std::vector<std::pair<std::string, std::unique_ptr<Expression>>>
+      interpolated_symbols;
 
+  InlineVerilog(std::string value,
+                std::vector<std::pair<std::string, std::unique_ptr<Expression>>>
+                    interpolated_symbols)
+      : value(value), interpolated_symbols(std::move(interpolated_symbols)){};
   InlineVerilog(std::string value) : value(value){};
-  std::string toString() { return value; };
+  std::string toString();
   ~InlineVerilog(){};
 };
 

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -191,6 +191,9 @@ std::unique_ptr<BlockComment> Transformer::visit(
 
 std::unique_ptr<InlineVerilog> Transformer::visit(
     std::unique_ptr<InlineVerilog> node) {
+  for (auto&& symbol : node->interpolated_symbols) {
+    symbol.second = this->visit(std::move(symbol.second));
+  }
   return node;
 }
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -464,4 +464,13 @@ std::string SingleLineComment::toString() {
   return result + "// " + value;
 }
 
+std::string InlineVerilog::toString() {
+    std::string result = value;
+    for (auto &&it : this->interpolated_symbols) {
+          result = std::regex_replace(
+              result, std::regex("\\{" + it.first + "\\}"), it.second->toString());
+    }
+    return result;
+}
+
 }  // namespace verilogAST

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -520,10 +520,17 @@ TEST(BasicTests, Comment) {
                        "verilator_public");
   EXPECT_EQ(port_with_comment->toString(), "input i/*verilator_public*/");
 }
+
 TEST(BasicTests, InlineVerilog) {
+  std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
+      interpolated_symbols;
+  interpolated_symbols.push_back(
+      std::make_pair("y", std::make_unique<vAST::NumericLiteral>(
+                              "10", 2, false, vAST::Radix::BINARY)));
   vAST::InlineVerilog inline_verilog(
       "logic [1:0] x;\n"
-      "assign x = 2'b10;\n");
+      "assign x = {y};\n",
+      std::move(interpolated_symbols));
   EXPECT_EQ(inline_verilog.toString(),
             "logic [1:0] x;\n"
             "assign x = 2'b10;\n");

--- a/tests/transformer.cpp
+++ b/tests/transformer.cpp
@@ -180,8 +180,11 @@ TEST(TransformerTests, TestModule) {
   body.push_back(
       std::make_unique<vAST::BlockComment>("Test comment\non multiple lines"));
 
-  body.push_back(
-      std::make_unique<vAST::InlineVerilog>("// Test inline verilog"));
+  std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>>
+      interpolated_symbols;
+  interpolated_symbols.push_back(std::make_pair("symbol", vAST::make_id("c")));
+  body.push_back(std::make_unique<vAST::InlineVerilog>(
+      "// Test inline verilog {symbol}", std::move(interpolated_symbols)));
 
   std::unique_ptr<vAST::AbstractModule> module = std::make_unique<vAST::Module>(
       "test_module0", std::move(ports), std::move(body), make_simple_params());
@@ -212,7 +215,7 @@ TEST(TransformerTests, TestModule) {
       "end\n\n"
       "// Test comment\n"
       "/*\nTest comment\non multiple lines\n*/\n"
-      "// Test inline verilog\n"
+      "// Test inline verilog g\n"
       "endmodule\n";
 
   ModuleTransformer transformer;


### PR DESCRIPTION
This extends inline verilog nodes to contain a list of symbols to be interpolated, to be used by https://github.com/rdaly525/coreir/pull/864

The goal is to provide a mapping from symbol to Identifier for interpolation, since these identifiers (e.g. a wire reference) might be inlined in a transformer, so the transformer should update the symbol mapping for the inlining logic.  (Effectively this stages interpolation until after inline has been run, so we get the final name for various references).