### PR TITLE
Always codegen size

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -71,7 +71,7 @@ class NumericLiteral : public Expression {
   Radix radix;        // default decimal
   // always generate size prefix (default false will not codegen size for 32
   // bit literals)
-  bool always_codegen_size;
+  bool always_codegen_size = false;
 
   NumericLiteral(std::string value, unsigned int size, bool _signed,
                  Radix radix, bool always_codegen_size)
@@ -86,36 +86,32 @@ class NumericLiteral : public Expression {
       : value(value),
         size(size),
         _signed(_signed),
-        radix(radix),
-        always_codegen_size(false){};
+        radix(radix){};
 
   NumericLiteral(std::string value, unsigned int size, bool _signed)
       : value(value),
         size(size),
         _signed(_signed),
-        radix(Radix::DECIMAL),
-        always_codegen_size(false){};
+        radix(Radix::DECIMAL){};
 
   NumericLiteral(std::string value, unsigned int size)
       : value(value),
         size(size),
         _signed(false),
-        radix(Radix::DECIMAL),
-        always_codegen_size(false){};
+        radix(Radix::DECIMAL){};
 
   NumericLiteral(std::string value)
       : value(value),
         size(32),
         _signed(false),
-        radix(Radix::DECIMAL),
-        always_codegen_size(false){};
+        radix(Radix::DECIMAL){};
 
   NumericLiteral(std::string value, Radix radix)
       : value(value),
         size(32),
         _signed(false),
-        radix(radix),
-        always_codegen_size(false){};
+        radix(radix){};
+
   std::string toString() override;
   auto clone() const { return std::unique_ptr<NumericLiteral>(clone_impl()); }
 };

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -69,22 +69,53 @@ class NumericLiteral : public Expression {
   unsigned int size;  // default 32
   bool _signed;       // default false
   Radix radix;        // default decimal
+  // always generate size prefix (default false will not codegen size for 32
+  // bit literals)
+  bool always_codegen_size;
+
+  NumericLiteral(std::string value, unsigned int size, bool _signed,
+                 Radix radix, bool always_codegen_size)
+      : value(value),
+        size(size),
+        _signed(_signed),
+        radix(radix),
+        always_codegen_size(always_codegen_size){};
 
   NumericLiteral(std::string value, unsigned int size, bool _signed,
                  Radix radix)
-      : value(value), size(size), _signed(_signed), radix(radix){};
+      : value(value),
+        size(size),
+        _signed(_signed),
+        radix(radix),
+        always_codegen_size(false){};
 
   NumericLiteral(std::string value, unsigned int size, bool _signed)
-      : value(value), size(size), _signed(_signed), radix(Radix::DECIMAL){};
+      : value(value),
+        size(size),
+        _signed(_signed),
+        radix(Radix::DECIMAL),
+        always_codegen_size(false){};
 
   NumericLiteral(std::string value, unsigned int size)
-      : value(value), size(size), _signed(false), radix(Radix::DECIMAL){};
+      : value(value),
+        size(size),
+        _signed(false),
+        radix(Radix::DECIMAL),
+        always_codegen_size(false){};
 
   NumericLiteral(std::string value)
-      : value(value), size(32), _signed(false), radix(Radix::DECIMAL){};
+      : value(value),
+        size(32),
+        _signed(false),
+        radix(Radix::DECIMAL),
+        always_codegen_size(false){};
 
   NumericLiteral(std::string value, Radix radix)
-      : value(value), size(32), _signed(false), radix(radix){};
+      : value(value),
+        size(32),
+        _signed(false),
+        radix(radix),
+        always_codegen_size(false){};
   std::string toString() override;
   auto clone() const { return std::unique_ptr<NumericLiteral>(clone_impl()); }
 };

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -55,6 +55,9 @@ std::string NumericLiteral::toString() {
       break;
   }
   std::string size_str = std::to_string(size);
+  if (size_str == "32" && !always_codegen_size) {
+    size_str = "";
+  }
 
   std::string separator = "";
   if (size_str + signed_str + radix_str != "") {

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -55,9 +55,6 @@ std::string NumericLiteral::toString() {
       break;
   }
   std::string size_str = std::to_string(size);
-  if (size_str == "32") {
-    size_str = "";
-  }
 
   std::string separator = "";
   if (size_str + signed_str + radix_str != "") {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -33,6 +33,10 @@ TEST(BasicTests, TestNumericLiteral) {
 
   vAST::NumericLiteral n8("z", vAST::Radix::HEX);
   EXPECT_EQ(n8.toString(), "'hz");
+
+  // Test always codegen prefix
+  vAST::NumericLiteral n9("DEADBEEF", 32, false, vAST::HEX, true);
+  EXPECT_EQ(n9.toString(), "32'hDEADBEEF");
 }
 
 TEST(BasicTests, TestIdentifier) {


### PR DESCRIPTION
Adds a flag to always code generate the size prefix for numeric literals (rather than using the default 32 bits logic).  Some linters require explicit sizes in all places for constant drivers (but not indexes), so having the ability to ignore the 32' prefix for indexes (e.g. x[1:0]) but not for constants, (e.g. assign x 32'bDEADBEEF) is nice.