### PR TITLE
Add cast node

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -91,7 +91,9 @@ class NumericLiteral : public Expression {
 
 class Cast : public Expression {
  protected:
-  virtual Cast* clone_impl() const override { return new Cast(*this); };
+  virtual Cast* clone_impl() const override {
+    return new Cast(this->width, this->expr->clone());
+  };
 
  public:
   // integer width because we want to avoid numeric literals with ' like 2'b01

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -89,6 +89,24 @@ class NumericLiteral : public Expression {
   auto clone() const { return std::unique_ptr<NumericLiteral>(clone_impl()); }
 };
 
+class Cast : public Expression {
+ protected:
+  virtual Cast* clone_impl() const override { return new Cast(*this); };
+
+ public:
+  // integer width because we want to avoid numeric literals with ' like 2'b01
+  unsigned int width;
+  std::unique_ptr<Expression> expr;
+
+  Cast(unsigned int width, std::unique_ptr<Expression> expr)
+      : width(width), expr(std::move(expr)){};
+  Cast(const Cast& rhs) : width(rhs.width), expr(expr->clone()){};
+  auto clone() const { return std::unique_ptr<Cast>(clone_impl()); }
+
+  std::string toString() override;
+  ~Cast(){};
+};
+
 // TODO also need a string literal, as strings can be used as parameter values
 
 class Identifier : public Expression {

--- a/include/verilogAST/transformer.hpp
+++ b/include/verilogAST/transformer.hpp
@@ -20,6 +20,8 @@ class Transformer {
 
   virtual std::unique_ptr<Identifier> visit(std::unique_ptr<Identifier> node);
 
+  virtual std::unique_ptr<Cast> visit(std::unique_ptr<Cast> node);
+
   virtual std::unique_ptr<Attribute> visit(std::unique_ptr<Attribute> node);
 
   virtual std::unique_ptr<String> visit(std::unique_ptr<String> node);

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -13,6 +13,10 @@ std::unique_ptr<Expression> Transformer::visit(
     node.release();
     return this->visit(std::unique_ptr<Identifier>(ptr));
   }
+  if (auto ptr = dynamic_cast<Cast*>(node.get())) {
+    node.release();
+    return this->visit(std::unique_ptr<Cast>(ptr));
+  }
   if (auto ptr = dynamic_cast<Attribute*>(node.get())) {
     node.release();
     return this->visit(std::unique_ptr<Attribute>(ptr));
@@ -64,6 +68,12 @@ std::unique_ptr<NumericLiteral> Transformer::visit(
 
 std::unique_ptr<Identifier> Transformer::visit(
     std::unique_ptr<Identifier> node) {
+  return node;
+}
+
+std::unique_ptr<Cast> Transformer::visit(
+    std::unique_ptr<Cast> node) {
+  node->expr = this->visit(std::move(node->expr));
   return node;
 }
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -122,6 +122,10 @@ std::string Identifier::toString() {
     return value;
 }
 
+std::string Cast::toString() {
+    return std::to_string(this->width) + "'(" + this->expr->toString() + ")";
+}
+
 std::string Attribute::toString() {
   return variant_to_string(this->value) + "." + this->attr;
 }

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -40,6 +40,13 @@ TEST(BasicTests, TestIdentifier) {
   EXPECT_EQ(id.toString(), "x");
 }
 
+TEST(BasicTests, TestCast) {
+  vAST::NumericLiteral n8("z", vAST::Radix::HEX);
+  vAST::Cast cast(5, vAST::make_id("x"));
+
+  EXPECT_EQ(cast.toString(), "5'(x)");
+}
+
 TEST(BasicTests, TestAttribute) {
   vAST::Attribute attr(vAST::make_id("x"), "y");
   EXPECT_EQ(attr.toString(), "x.y");

--- a/tests/transformer.cpp
+++ b/tests/transformer.cpp
@@ -95,12 +95,13 @@ TEST(TransformerTests, TestXtoZ) {
               vAST::UnOp::INVERT)),
       std::make_unique<vAST::Replicate>(vAST::make_num("2"),
                                         vAST::make_id("x"))));
-  call_args.push_back(vAST::make_id("x"));
+  call_args.push_back(
+      std::make_unique<vAST::Cast>(5, vAST::make_id("x")));
   std::unique_ptr<vAST::Expression> expr =
       std::make_unique<vAST::CallExpr>("my_func", std::move(call_args));
   XtoZ transformer;
   EXPECT_EQ(transformer.visit(std::move(expr))->toString(),
-            "my_func({z,b} ? z.j[3:1] + (~ y[1]) : {(2){z}}, z)");
+            "my_func({z,b} ? z.j[3:1] + (~ y[1]) : {(2){z}}, 5'(z))");
 }
 TEST(TransformerTests, TestReplaceNameWithExpr) {
   std::unique_ptr<vAST::Expression> expr = vAST::make_binop(


### PR DESCRIPTION
Adds support for basic width casting.  Need these to be inserted in various places (e.g. around + operations that implicitly promote the input widths by 1).