### PR TITLE
Support slice and attribute for value of index

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -83,34 +83,19 @@ class NumericLiteral : public Expression {
 
   NumericLiteral(std::string value, unsigned int size, bool _signed,
                  Radix radix)
-      : value(value),
-        size(size),
-        _signed(_signed),
-        radix(radix){};
+      : value(value), size(size), _signed(_signed), radix(radix){};
 
   NumericLiteral(std::string value, unsigned int size, bool _signed)
-      : value(value),
-        size(size),
-        _signed(_signed),
-        radix(Radix::DECIMAL){};
+      : value(value), size(size), _signed(_signed), radix(Radix::DECIMAL){};
 
   NumericLiteral(std::string value, unsigned int size)
-      : value(value),
-        size(size),
-        _signed(false),
-        radix(Radix::DECIMAL){};
+      : value(value), size(size), _signed(false), radix(Radix::DECIMAL){};
 
   NumericLiteral(std::string value)
-      : value(value),
-        size(32),
-        _signed(false),
-        radix(Radix::DECIMAL){};
+      : value(value), size(32), _signed(false), radix(Radix::DECIMAL){};
 
   NumericLiteral(std::string value, Radix radix)
-      : value(value),
-        size(32),
-        _signed(false),
-        radix(radix){};
+      : value(value), size(32), _signed(false), radix(radix){};
 
   std::string toString() override;
   auto clone() const { return std::unique_ptr<NumericLiteral>(clone_impl()); }
@@ -237,10 +222,12 @@ class Slice : public Expression {
 };
 
 class Index : public Expression {
-  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Slice>>
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>,
+               std::unique_ptr<Slice>>
   clone_index_value() const {
     return std::visit(
         [](auto&& value) -> std::variant<std::unique_ptr<Identifier>,
+                                         std::unique_ptr<Attribute>,
                                          std::unique_ptr<Slice>> {
           return value->clone();
         },
@@ -253,10 +240,14 @@ class Index : public Expression {
   };
 
  public:
-  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Slice>> value;
+  std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>,
+               std::unique_ptr<Slice>>
+      value;
   std::unique_ptr<Expression> index;
 
-  Index(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Slice>> value,
+  Index(std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>,
+                     std::unique_ptr<Slice>>
+            value,
         std::unique_ptr<Expression> index)
       : value(std::move(value)), index(std::move(index)){};
 

--- a/include/verilogAST/assign_inliner.hpp
+++ b/include/verilogAST/assign_inliner.hpp
@@ -59,6 +59,7 @@ class IndexBlacklister : public Transformer {
   //
   // Verilog does not support (y + z)[0]
   std::set<std::string> &wire_blacklist;
+  bool inside_index = false;
 
  public:
   IndexBlacklister(std::set<std::string> &wire_blacklist)
@@ -66,6 +67,7 @@ class IndexBlacklister : public Transformer {
 
   using Transformer::visit;
   virtual std::unique_ptr<Index> visit(std::unique_ptr<Index> node);
+  virtual std::unique_ptr<Identifier> visit(std::unique_ptr<Identifier> node);
 };
 
 class AssignInliner : public Transformer {
@@ -87,9 +89,9 @@ class AssignInliner : public Transformer {
   bool can_inline(std::string key);
 
  public:
-  AssignInliner() : wire_blacklist() {};
-  explicit AssignInliner(std::set<std::string> wire_blacklist) :
-      wire_blacklist(wire_blacklist) {};
+  AssignInliner() : wire_blacklist(){};
+  explicit AssignInliner(std::set<std::string> wire_blacklist)
+      : wire_blacklist(wire_blacklist){};
   using Transformer::visit;
   virtual std::unique_ptr<Expression> visit(std::unique_ptr<Expression> node);
   virtual std::unique_ptr<ContinuousAssign> visit(

--- a/src/concat_coalescer.cpp
+++ b/src/concat_coalescer.cpp
@@ -1,5 +1,5 @@
-#include <cassert>
 #include "verilogAST/concat_coalescer.hpp"
+#include <cassert>
 
 namespace verilogAST {
 
@@ -8,7 +8,7 @@ namespace {
 struct Run {
   std::string name;
   int first;  // inclusive
-  int last;  // inclusive
+  int last;   // inclusive
 };
 
 class RunOrExpr {
@@ -69,7 +69,11 @@ RunOrExpr makeRunOrExpr(const Expression* arg) {
   if (not index) return RunOrExpr(arg);
   auto as_int = expr_to_int(index->index.get());
   if (not as_int.first) return RunOrExpr(arg);
-  return RunOrExpr(index->id->value, as_int.second, as_int.second);
+  if (not std::holds_alternative<std::unique_ptr<Identifier>>(index->value)) {
+    return RunOrExpr(arg);
+  }
+  auto& id = std::get<std::unique_ptr<Identifier>>(index->value);
+  return RunOrExpr(id->value, as_int.second, as_int.second);
 }
 
 }  // namespace

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -88,7 +88,7 @@ std::unique_ptr<String> Transformer::visit(std::unique_ptr<String> node) {
 }
 
 std::unique_ptr<Index> Transformer::visit(std::unique_ptr<Index> node) {
-  node->id = this->visit(std::move(node->id));
+  node->value = this->visit(std::move(node->value));
   node->index = this->visit(std::move(node->index));
   return node;
 }

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -133,7 +133,7 @@ std::string Attribute::toString() {
 std::string String::toString() { return "\"" + value + "\""; }
 
 std::string Index::toString() {
-  return id->toString() + '[' + index->toString() + ']';
+  return variant_to_string(value) + '[' + index->toString() + ']';
 }
 
 std::string Slice::toString() {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -77,6 +77,11 @@ TEST(BasicTests, TestString) {
 TEST(BasicTests, TestIndex) {
   vAST::Index index(vAST::make_id("x"), vAST::make_num("0"));
   EXPECT_EQ(index.toString(), "x[0]");
+  vAST::Index index2(
+      std::make_unique<vAST::Slice>(vAST::make_id("x"), vAST::make_num("3"),
+                                    vAST::make_num("0")),
+      vAST::make_num("0"));
+  EXPECT_EQ(index2.toString(), "x[3:0][0]");
 }
 
 TEST(BasicTests, TestSlice) {
@@ -289,14 +294,14 @@ TEST(BasicTests, TestModuleInst) {
                                         make_simple_connections());
 
   EXPECT_EQ(module_inst.toString(),
-          "test_module #(\n"
-          "    .param0(0),\n"
-          "    .param1(1)\n"
-          ") test_module_inst (\n"
-          "    .a(a),\n"
-          "    .b(b[0]),\n"
-          "    .c(c[31:0])\n"
-          ");");
+            "test_module #(\n"
+            "    .param0(0),\n"
+            "    .param1(1)\n"
+            ") test_module_inst (\n"
+            "    .a(a),\n"
+            "    .b(b[0]),\n"
+            "    .c(c[31:0])\n"
+            ");");
 }
 
 TEST(BasicTests, TestModule) {
@@ -580,7 +585,7 @@ TEST(BasicTests, TestIndexCopy) {
   std::unique_ptr<vAST::Index> x1 = std::make_unique<vAST::Index>(*x);
   EXPECT_EQ(x->toString(), "x[y]");
   EXPECT_EQ(x1->toString(), "x[y]");
-  x1->id->value = "z";
+  x1->value = vAST::make_id("z");
   x1->index = std::make_unique<vAST::Identifier>("a");
   EXPECT_EQ(x->toString(), "x[y]");
   EXPECT_EQ(x1->toString(), "z[a]");

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -77,11 +77,16 @@ TEST(BasicTests, TestString) {
 TEST(BasicTests, TestIndex) {
   vAST::Index index(vAST::make_id("x"), vAST::make_num("0"));
   EXPECT_EQ(index.toString(), "x[0]");
+
   vAST::Index index2(
       std::make_unique<vAST::Slice>(vAST::make_id("x"), vAST::make_num("3"),
                                     vAST::make_num("0")),
       vAST::make_num("0"));
   EXPECT_EQ(index2.toString(), "x[3:0][0]");
+
+  vAST::Index index3(std::make_unique<vAST::Attribute>(vAST::make_id("x"), "y"),
+                     vAST::make_num("0"));
+  EXPECT_EQ(index3.toString(), "x.y[0]");
 }
 
 TEST(BasicTests, TestSlice) {


### PR DESCRIPTION
This extends the index node to support slices and attributes so we can have things like `x[3:0][0]` and `x.y[1]`.

For now, it updates the ConcatCoalescer to only work when the index value is an Identifier (the current assumption), we can look into improving this in the future but the addition of the upstream Slice representation in coreir may deprecate the need for this pass.