### PR TITLE
Improve slice/index inlining logic

### DIFF
--- a/src/assign_inliner.cpp
+++ b/src/assign_inliner.cpp
@@ -7,9 +7,12 @@ std::unique_ptr<Identifier> Blacklister::visit(
     std::unique_ptr<Identifier> node) {
   if (this->blacklist) {
     auto it = assign_map.find(node->toString());
-    bool assigned_to_id =
-        it != assign_map.end() && dynamic_cast<Identifier*>(it->second.get());
-    if (!assigned_to_id) {
+    // Can only inline if driven by identifier, index, or slice
+    bool valid_driver = it != assign_map.end() &&
+                        (dynamic_cast<Identifier*>(it->second.get()) ||
+                         dynamic_cast<Index*>(it->second.get()) ||
+                         dynamic_cast<Slice*>(it->second.get()));
+    if (!valid_driver) {
       this->wire_blacklist.insert(node->value);
     }
   }


### PR DESCRIPTION
We generally can't inline into slice/index nodes because we can't have
expressions such as `(x + y)[1:0]`.  However, we can have nested
index/slice nodes, so we improve the blacklisting logic to not block
inlining if we see a slice or index driver.

Note, we assume that the index/slice driver is well formed, so if we
have a driver of the form <...>[3:0], the contents of the slice (<...>)
are assumed to be valid (so it could contain an ID, another slice, or an
index).