### PR TITLE
Fix inline blacklist logic for recursive case

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -807,6 +807,13 @@ class If : public BehavioralStatement {
         else_ifs(std::move(else_ifs)),
         else_body(std::move(else_body)){};
 
+  If(std::unique_ptr<Expression> cond,
+     std::vector<std::unique_ptr<BehavioralStatement>> true_body,
+     std::vector<std::unique_ptr<BehavioralStatement>> else_body)
+      : cond(std::move(cond)),
+        true_body(std::move(true_body)),
+        else_body(std::move(else_body)){};
+
   std::string toString();
   ~If(){};
 };

--- a/include/verilogAST/assign_inliner.hpp
+++ b/include/verilogAST/assign_inliner.hpp
@@ -67,6 +67,7 @@ class Blacklister : public Transformer {
 
  protected:
   bool blacklist = false;
+  void blacklist_invalid_driver(std::unique_ptr<Identifier> node);
 
  public:
   Blacklister(std::set<std::string> &wire_blacklist,

--- a/include/verilogAST/assign_inliner.hpp
+++ b/include/verilogAST/assign_inliner.hpp
@@ -67,6 +67,9 @@ class Blacklister : public Transformer {
 
  protected:
   bool blacklist = false;
+  // Allow numeric literals as valid drivers (okay for module instances, not
+  // okay for slice/index)
+  virtual bool allowNumDriver() { return false; };
   void blacklist_invalid_driver(std::unique_ptr<Identifier> node);
 
  public:
@@ -124,6 +127,9 @@ class ModuleInstanceBlacklister : public Blacklister {
   // We can make this configurable, but for now we keep it as the default since
   // some tools do not support general expressions inside module instance
   // statements
+ protected:
+  bool allowNumDriver() override { return true; };
+
  public:
   ModuleInstanceBlacklister(
       std::set<std::string> &wire_blacklist,
@@ -131,7 +137,7 @@ class ModuleInstanceBlacklister : public Blacklister {
       : Blacklister(wire_blacklist, assign_map){};
   using Blacklister::visit;
   virtual std::unique_ptr<ModuleInstantiation> visit(
-      std::unique_ptr<ModuleInstantiation> node);
+      std::unique_ptr<ModuleInstantiation> node) override;
 };
 
 class AssignInliner : public Transformer {

--- a/src/assign_inliner.cpp
+++ b/src/assign_inliner.cpp
@@ -13,7 +13,8 @@ void Blacklister::blacklist_invalid_driver(std::unique_ptr<Identifier> node) {
   // Can only inline if driven by identifier, index, or slice
   bool valid_driver = dynamic_cast<Identifier*>(driver.get()) ||
                       dynamic_cast<Index*>(driver.get()) ||
-                      dynamic_cast<Slice*>(driver.get());
+                      dynamic_cast<Slice*>(driver.get()) ||
+                      dynamic_cast<NumericLiteral*>(driver.get());
   if (!valid_driver) {
     this->wire_blacklist.insert(node->value);
   } else if (auto ptr = dynamic_cast<Identifier*>(driver.get())) {

--- a/src/assign_inliner.cpp
+++ b/src/assign_inliner.cpp
@@ -15,10 +15,11 @@ void Blacklister::blacklist_invalid_driver(std::unique_ptr<Identifier> node) {
   }
   auto driver = assign_map[node->toString()]->clone();
   // Can only inline if driven by identifier, index, or slice
-  bool valid_driver = dynamic_cast<Identifier*>(driver.get()) ||
-                      dynamic_cast<Index*>(driver.get()) ||
-                      dynamic_cast<Slice*>(driver.get()) ||
-                      dynamic_cast<NumericLiteral*>(driver.get());
+  bool valid_driver =
+      dynamic_cast<Identifier*>(driver.get()) ||
+      dynamic_cast<Index*>(driver.get()) ||
+      dynamic_cast<Slice*>(driver.get()) ||
+      (this->allowNumDriver() && dynamic_cast<NumericLiteral*>(driver.get()));
   if (!valid_driver) {
     this->wire_blacklist.insert(node->value);
   } else if (auto ptr = dynamic_cast<Identifier*>(driver.get())) {

--- a/src/assign_inliner.cpp
+++ b/src/assign_inliner.cpp
@@ -51,6 +51,16 @@ std::unique_ptr<Index> IndexBlacklister::visit(std::unique_ptr<Index> node) {
   return node;
 }
 
+std::unique_ptr<ModuleInstantiation> ModuleInstanceBlacklister::visit(
+    std::unique_ptr<ModuleInstantiation> node) {
+  this->blacklist = true;
+  for (auto&& conn : *node->connections) {
+    conn.second = this->visit(std::move(conn.second));
+  }
+  this->blacklist = false;
+  return node;
+}
+
 std::unique_ptr<Identifier> WireReadCounter::visit(
     std::unique_ptr<Identifier> node) {
   this->read_count[node->toString()]++;
@@ -258,6 +268,10 @@ std::unique_ptr<Module> AssignInliner::visit(std::unique_ptr<Module> node) {
 
   SliceBlacklister slice_blacklist(this->wire_blacklist, this->assign_map);
   node = slice_blacklist.visit(std::move(node));
+
+  ModuleInstanceBlacklister module_instance_blacklister(this->wire_blacklist,
+                                                        this->assign_map);
+  node = module_instance_blacklister.visit(std::move(node));
 
   std::vector<std::unique_ptr<AbstractPort>> new_ports;
   for (auto&& item : node->ports) {

--- a/tests/assign_inliner.cpp
+++ b/tests/assign_inliner.cpp
@@ -961,6 +961,122 @@ TEST(InlineAssignTests, TestInlineSliceOfIndex) {
   EXPECT_EQ(transformer.visit(std::move(module))->toString(), expected_str);
 }
 
+TEST(InlineAssignTests, TestInlineMultipleAssign) {
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Vector>(vAST::make_id("i0"), vAST::make_num("4"),
+                                     vAST::make_num("0")),
+      vAST::INPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Vector>(vAST::make_id("i1"), vAST::make_num("4"),
+                                     vAST::make_num("0")),
+      vAST::INPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(vAST::make_id("s"), vAST::INPUT,
+                                               vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Vector>(vAST::make_id("o"), vAST::make_num("3"),
+                                     vAST::make_num("0")),
+      vAST::OUTPUT, vAST::WIRE));
+
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+
+  body.push_back(std::make_unique<vAST::Wire>(std::make_unique<vAST::Vector>(
+      vAST::make_id("x"), vAST::make_num("4"), vAST::make_num("0"))));
+
+  body.push_back(std::make_unique<vAST::Wire>(std::make_unique<vAST::Vector>(
+      vAST::make_id("y"), vAST::make_num("4"), vAST::make_num("0"))));
+
+  body.push_back(std::make_unique<vAST::Wire>(std::make_unique<vAST::Vector>(
+      vAST::make_id("z"), vAST::make_num("4"), vAST::make_num("0"))));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(vAST::make_id("x"),
+                                                          vAST::make_id("i0")));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(vAST::make_id("y"),
+                                                          vAST::make_id("i1")));
+
+  std::vector<std::variant<
+      std::unique_ptr<vAST::Identifier>, std::unique_ptr<vAST::PosEdge>,
+      std::unique_ptr<vAST::NegEdge>, std::unique_ptr<vAST::Star>>>
+      sensitivity_list;
+  sensitivity_list.push_back(std::make_unique<vAST::Star>());
+
+  std::vector<std::unique_ptr<vAST::BehavioralStatement>> always_body;
+
+  std::vector<std::unique_ptr<vAST::BehavioralStatement>> true_body;
+  true_body.push_back(std::make_unique<vAST::BlockingAssign>(
+      std::make_unique<vAST::Identifier>("z"),
+      std::make_unique<vAST::Identifier>("x")));
+
+  std::vector<std::unique_ptr<vAST::BehavioralStatement>> else_body;
+  else_body.push_back(std::make_unique<vAST::BlockingAssign>(
+      std::make_unique<vAST::Identifier>("z"),
+      std::make_unique<vAST::Identifier>("y")));
+
+  always_body.push_back(std::make_unique<vAST::If>(
+      vAST::make_id("s"), std::move(true_body), std::move(else_body)));
+
+  body.push_back(std::make_unique<vAST::Always>(std::move(sensitivity_list),
+                                                std::move(always_body)));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(
+      vAST::make_id("o"),
+      std::make_unique<vAST::Slice>(vAST::make_id("z"), vAST::make_num("3"),
+                                    vAST::make_num("0"))));
+
+  std::unique_ptr<vAST::AbstractModule> module = std::make_unique<vAST::Module>(
+      "test_module", std::move(ports), std::move(body));
+
+  std::string raw_str =
+      "module test_module (\n"
+      "    input [4:0] i0,\n"
+      "    input [4:0] i1,\n"
+      "    input s,\n"
+      "    output [3:0] o\n"
+      ");\n"
+      "wire [4:0] x;\n"
+      "wire [4:0] y;\n"
+      "wire [4:0] z;\n"
+      "assign x = i0;\n"
+      "assign y = i1;\n"
+      "always @(*) begin\n"
+      "if (s) begin\n"
+      "    z = x;\n"
+      "end else begin\n"
+      "    z = y;\n"
+      "end\n"
+      "end\n"
+      "\n"
+      "assign o = z[3:0];\n"
+      "endmodule\n";
+
+  EXPECT_EQ(module->toString(), raw_str);
+
+  std::string expected_str =
+      "module test_module (\n"
+      "    input [4:0] i0,\n"
+      "    input [4:0] i1,\n"
+      "    input s,\n"
+      "    output [3:0] o\n"
+      ");\n"
+      "wire [4:0] z;\n"
+      "always @(*) begin\n"
+      "if (s) begin\n"
+      "    z = i0;\n"
+      "end else begin\n"
+      "    z = i1;\n"
+      "end\n"
+      "end\n"
+      "\n"
+      "assign o = z[3:0];\n"
+      "endmodule\n";
+
+  vAST::AssignInliner transformer;
+  EXPECT_EQ(transformer.visit(std::move(module))->toString(), expected_str);
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Before if we had a module such as:
```verilog
module test_module (
    input [4:0] i1,
    input [4:0] i2,
    output [3:0] o0,
    output [3:0] o1,
    output [3:0] o2
);
wire [4:0] x;
wire [4:0] y;
wire [4:0] h;
wire [4:0] g;
assign x = i1 + i2;
assign h = i1 - i2;
assign g = h;
assign o0 = x[3:0];
assign y = i1;
assign o1 = y[3:0];
assign o2 = g[3:0];
endmodule;
```

We would get

```verilog
module test_module (
    input [4:0] i1,
    input [4:0] i2,
    output [3:0] o0,
    output [3:0] o1,
    output [3:0] o2
);
wire [4:0] x;
wire [4:0] h;
assign x = i1 + i2;
assign o0 = x[3:0];
assign o1 = i1[3:0];
assign o2 = (i1 - i2)[3:0];
endmodule;
```

Notice the (i1 - i2) is inlined into the slice node, which is invalid.

The reason was the blacklisting logic was not recursively checking
identifiers.  That is, when we encounter a slice, we let a an
identifier be inlined for another identifier into the contents of the
slice.  However, this is problematic when the identifier being inlined
will in turn be replaced by something which may not be valid (e.g. an
expression).  So, we improve the blacklisting logic to recursively check
inlined identifiers until we encounter an invalid driver of inlining.
At this point, we blacklist the current identifier so that it will not
be eventually inlined into the slice/index node.

So, for the above example we now get
```verilog
module test_module (
    input [4:0] i1,
    input [4:0] i2,
    output [3:0] o0,
    output [3:0] o1,
    output [3:0] o2
);
wire [4:0] x;
wire [4:0] h;
assign x = i1 + i2;
assign h = i1 - i2;
assign o0 = x[3:0];
assign o1 = i1[3:0];
assign o2 = h[3:0];
endmodule;
```