### PR TITLE
Fix handling of multiple assignments in inlining

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -807,6 +807,13 @@ class If : public BehavioralStatement {
         else_ifs(std::move(else_ifs)),
         else_body(std::move(else_body)){};
 
+  If(std::unique_ptr<Expression> cond,
+     std::vector<std::unique_ptr<BehavioralStatement>> true_body,
+     std::vector<std::unique_ptr<BehavioralStatement>> else_body)
+      : cond(std::move(cond)),
+        true_body(std::move(true_body)),
+        else_body(std::move(else_body)){};
+
   std::string toString();
   ~If(){};
 };

--- a/include/verilogAST/assign_inliner.hpp
+++ b/include/verilogAST/assign_inliner.hpp
@@ -67,6 +67,9 @@ class Blacklister : public Transformer {
 
  protected:
   bool blacklist = false;
+  // Allow numeric literals as valid drivers (okay for module instances, not
+  // okay for slice/index)
+  virtual bool allowNumDriver() { return false; };
   void blacklist_invalid_driver(std::unique_ptr<Identifier> node);
 
  public:
@@ -124,6 +127,9 @@ class ModuleInstanceBlacklister : public Blacklister {
   // We can make this configurable, but for now we keep it as the default since
   // some tools do not support general expressions inside module instance
   // statements
+ protected:
+  bool allowNumDriver() override { return true; };
+
  public:
   ModuleInstanceBlacklister(
       std::set<std::string> &wire_blacklist,
@@ -131,7 +137,7 @@ class ModuleInstanceBlacklister : public Blacklister {
       : Blacklister(wire_blacklist, assign_map){};
   using Blacklister::visit;
   virtual std::unique_ptr<ModuleInstantiation> visit(
-      std::unique_ptr<ModuleInstantiation> node);
+      std::unique_ptr<ModuleInstantiation> node) override;
 };
 
 class AssignInliner : public Transformer {

--- a/src/assign_inliner.cpp
+++ b/src/assign_inliner.cpp
@@ -15,10 +15,11 @@ void Blacklister::blacklist_invalid_driver(std::unique_ptr<Identifier> node) {
   }
   auto driver = assign_map[node->toString()]->clone();
   // Can only inline if driven by identifier, index, or slice
-  bool valid_driver = dynamic_cast<Identifier*>(driver.get()) ||
-                      dynamic_cast<Index*>(driver.get()) ||
-                      dynamic_cast<Slice*>(driver.get()) ||
-                      dynamic_cast<NumericLiteral*>(driver.get());
+  bool valid_driver =
+      dynamic_cast<Identifier*>(driver.get()) ||
+      dynamic_cast<Index*>(driver.get()) ||
+      dynamic_cast<Slice*>(driver.get()) ||
+      (this->allowNumDriver() && dynamic_cast<NumericLiteral*>(driver.get()));
   if (!valid_driver) {
     this->wire_blacklist.insert(node->value);
   } else if (auto ptr = dynamic_cast<Identifier*>(driver.get())) {

--- a/tests/assign_inliner.cpp
+++ b/tests/assign_inliner.cpp
@@ -961,6 +961,122 @@ TEST(InlineAssignTests, TestInlineSliceOfIndex) {
   EXPECT_EQ(transformer.visit(std::move(module))->toString(), expected_str);
 }
 
+TEST(InlineAssignTests, TestInlineMultipleAssign) {
+  std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Vector>(vAST::make_id("i0"), vAST::make_num("4"),
+                                     vAST::make_num("0")),
+      vAST::INPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Vector>(vAST::make_id("i1"), vAST::make_num("4"),
+                                     vAST::make_num("0")),
+      vAST::INPUT, vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(vAST::make_id("s"), vAST::INPUT,
+                                               vAST::WIRE));
+  ports.push_back(std::make_unique<vAST::Port>(
+      std::make_unique<vAST::Vector>(vAST::make_id("o"), vAST::make_num("3"),
+                                     vAST::make_num("0")),
+      vAST::OUTPUT, vAST::WIRE));
+
+  std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
+                           std::unique_ptr<vAST::Declaration>>>
+      body;
+
+  body.push_back(std::make_unique<vAST::Wire>(std::make_unique<vAST::Vector>(
+      vAST::make_id("x"), vAST::make_num("4"), vAST::make_num("0"))));
+
+  body.push_back(std::make_unique<vAST::Wire>(std::make_unique<vAST::Vector>(
+      vAST::make_id("y"), vAST::make_num("4"), vAST::make_num("0"))));
+
+  body.push_back(std::make_unique<vAST::Wire>(std::make_unique<vAST::Vector>(
+      vAST::make_id("z"), vAST::make_num("4"), vAST::make_num("0"))));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(vAST::make_id("x"),
+                                                          vAST::make_id("i0")));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(vAST::make_id("y"),
+                                                          vAST::make_id("i1")));
+
+  std::vector<std::variant<
+      std::unique_ptr<vAST::Identifier>, std::unique_ptr<vAST::PosEdge>,
+      std::unique_ptr<vAST::NegEdge>, std::unique_ptr<vAST::Star>>>
+      sensitivity_list;
+  sensitivity_list.push_back(std::make_unique<vAST::Star>());
+
+  std::vector<std::unique_ptr<vAST::BehavioralStatement>> always_body;
+
+  std::vector<std::unique_ptr<vAST::BehavioralStatement>> true_body;
+  true_body.push_back(std::make_unique<vAST::BlockingAssign>(
+      std::make_unique<vAST::Identifier>("z"),
+      std::make_unique<vAST::Identifier>("x")));
+
+  std::vector<std::unique_ptr<vAST::BehavioralStatement>> else_body;
+  else_body.push_back(std::make_unique<vAST::BlockingAssign>(
+      std::make_unique<vAST::Identifier>("z"),
+      std::make_unique<vAST::Identifier>("y")));
+
+  always_body.push_back(std::make_unique<vAST::If>(
+      vAST::make_id("s"), std::move(true_body), std::move(else_body)));
+
+  body.push_back(std::make_unique<vAST::Always>(std::move(sensitivity_list),
+                                                std::move(always_body)));
+
+  body.push_back(std::make_unique<vAST::ContinuousAssign>(
+      vAST::make_id("o"),
+      std::make_unique<vAST::Slice>(vAST::make_id("z"), vAST::make_num("3"),
+                                    vAST::make_num("0"))));
+
+  std::unique_ptr<vAST::AbstractModule> module = std::make_unique<vAST::Module>(
+      "test_module", std::move(ports), std::move(body));
+
+  std::string raw_str =
+      "module test_module (\n"
+      "    input [4:0] i0,\n"
+      "    input [4:0] i1,\n"
+      "    input s,\n"
+      "    output [3:0] o\n"
+      ");\n"
+      "wire [4:0] x;\n"
+      "wire [4:0] y;\n"
+      "wire [4:0] z;\n"
+      "assign x = i0;\n"
+      "assign y = i1;\n"
+      "always @(*) begin\n"
+      "if (s) begin\n"
+      "    z = x;\n"
+      "end else begin\n"
+      "    z = y;\n"
+      "end\n"
+      "end\n"
+      "\n"
+      "assign o = z[3:0];\n"
+      "endmodule\n";
+
+  EXPECT_EQ(module->toString(), raw_str);
+
+  std::string expected_str =
+      "module test_module (\n"
+      "    input [4:0] i0,\n"
+      "    input [4:0] i1,\n"
+      "    input s,\n"
+      "    output [3:0] o\n"
+      ");\n"
+      "wire [4:0] z;\n"
+      "always @(*) begin\n"
+      "if (s) begin\n"
+      "    z = i0;\n"
+      "end else begin\n"
+      "    z = i1;\n"
+      "end\n"
+      "end\n"
+      "\n"
+      "assign o = z[3:0];\n"
+      "endmodule\n";
+
+  vAST::AssignInliner transformer;
+  EXPECT_EQ(transformer.visit(std::move(module))->toString(), expected_str);
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This fixes a case where multiple assignments to a variable were not being treated properly in the nested blacklisting logic.  Here's an example where this code:
```verilog
module Mux2xArray3_Array2_OutBit (
    input [1:0] I0 [2:0],
    input [1:0] I1 [2:0],
    input S,
    output [1:0] O [2:0]
);
reg [5:0] coreir_commonlib_mux2x6_inst0_out_unq1;
wire [5:0] coreir_commonlib_mux2x6_inst0_in_data_0;
wire [5:0] coreir_commonlib_mux2x6_inst0_in_data_1;
wire [5:0] coreir_commonlib_mux2x6_inst0_out;
always @(*) begin
if (S == 0) begin
    coreir_commonlib_mux2x6_inst0_out_unq1 = coreir_commonlib_mux2x6_inst0_in_data_0;
end else begin
    coreir_commonlib_mux2x6_inst0_out_unq1 = coreir_commonlib_mux2x6_inst0_in_data_1;
end
end

assign coreir_commonlib_mux2x6_inst0_in_data_0 = {I0[2][1:0],I0[1][1:0],I0[0][1:0]};
assign coreir_commonlib_mux2x6_inst0_in_data_1 = {I1[2][1:0],I1[1][1:0],I1[0][1:0]};
assign coreir_commonlib_mux2x6_inst0_out = coreir_commonlib_mux2x6_inst0_out_unq1;
assign O[2] = coreir_commonlib_mux2x6_inst0_out_unq1[5:4];
assign O[1] = coreir_commonlib_mux2x6_inst0_out_unq1[3:2];
assign O[0] = coreir_commonlib_mux2x6_inst0_out_unq1[1:0];
endmodule
```

would turn into

```verilog
module Mux2xArray3_Array2_OutBit (
    input [1:0] I0 [2:0],
    input [1:0] I1 [2:0],
    input S,
    output [1:0] O [2:0]
);
reg [5:0] coreir_commonlib_mux2x6_inst0_out_unq1;
wire [5:0] coreir_commonlib_mux2x6_inst0_in_data_1;
always @(*) begin
if (S == 0) begin
    coreir_commonlib_mux2x6_inst0_out_unq1 = {I0[2][1:0],I0[1][1:0],I0[0][1:0]};
end else begin
    coreir_commonlib_mux2x6_inst0_out_unq1 = coreir_commonlib_mux2x6_inst0_in_data_1;
end
end

assign coreir_commonlib_mux2x6_inst0_in_data_1 = {I1[2][1:0],I1[1][1:0],I1[0][1:0]};
assign O[2] = coreir_commonlib_mux2x6_inst0_out_unq1[5:4];
assign O[1] = coreir_commonlib_mux2x6_inst0_out_unq1[3:2];
assign O[0] = coreir_commonlib_mux2x6_inst0_out_unq1[1:0];
endmodule
```

Notice `coreir_commonlib_mux2x6_inst0_in_data_1` isn't inlined, this is because it drives `coreir_commonlib_mux2x6_inst0_out_unq1` which in turn drives a slice that shouldn't be inlined, so the recursive inline logic prevents it from being inlined.  

However, it should see that `coreir_commonlib_mux2x6_inst0_out_unq1` is assigned twice, so it won't be inlined, which then allows `coreir_commonlib_mux2x6_inst0_in_data_1`.

This change moves the assignment count logic up to the front to blacklist wires from being inlined if they're assigned more than once, than updates the recursive blacklisting logic to detect and stop when it encounters a wire that's already being blacklisted (which then allows other drivers to be inlined, rather than continuing to recurse).

Also adds a convenience construct to If when there are no else_ifs