### PR TITLE
Prevents numeric literals from being inlined into index/slice nodes

### DIFF
--- a/include/verilogAST/assign_inliner.hpp
+++ b/include/verilogAST/assign_inliner.hpp
@@ -67,6 +67,9 @@ class Blacklister : public Transformer {
 
  protected:
   bool blacklist = false;
+  // Allow numeric literals as valid drivers (okay for module instances, not
+  // okay for slice/index)
+  virtual bool allowNumDriver() { return false; };
   void blacklist_invalid_driver(std::unique_ptr<Identifier> node);
 
  public:
@@ -124,6 +127,9 @@ class ModuleInstanceBlacklister : public Blacklister {
   // We can make this configurable, but for now we keep it as the default since
   // some tools do not support general expressions inside module instance
   // statements
+ protected:
+  bool allowNumDriver() override { return true; };
+
  public:
   ModuleInstanceBlacklister(
       std::set<std::string> &wire_blacklist,
@@ -131,7 +137,7 @@ class ModuleInstanceBlacklister : public Blacklister {
       : Blacklister(wire_blacklist, assign_map){};
   using Blacklister::visit;
   virtual std::unique_ptr<ModuleInstantiation> visit(
-      std::unique_ptr<ModuleInstantiation> node);
+      std::unique_ptr<ModuleInstantiation> node) override;
 };
 
 class AssignInliner : public Transformer {

--- a/src/assign_inliner.cpp
+++ b/src/assign_inliner.cpp
@@ -15,10 +15,11 @@ void Blacklister::blacklist_invalid_driver(std::unique_ptr<Identifier> node) {
   }
   auto driver = assign_map[node->toString()]->clone();
   // Can only inline if driven by identifier, index, or slice
-  bool valid_driver = dynamic_cast<Identifier*>(driver.get()) ||
-                      dynamic_cast<Index*>(driver.get()) ||
-                      dynamic_cast<Slice*>(driver.get()) ||
-                      dynamic_cast<NumericLiteral*>(driver.get());
+  bool valid_driver =
+      dynamic_cast<Identifier*>(driver.get()) ||
+      dynamic_cast<Index*>(driver.get()) ||
+      dynamic_cast<Slice*>(driver.get()) ||
+      (this->allowNumDriver() && dynamic_cast<NumericLiteral*>(driver.get()));
   if (!valid_driver) {
     this->wire_blacklist.insert(node->value);
   } else if (auto ptr = dynamic_cast<Identifier*>(driver.get())) {


### PR DESCRIPTION
We can inline these into module instance statements, but we can't have
something like `(7)[0]` so we prevent inlining of numeric literals into
index/slice nodes.