### PR TITLE
Simplify ID sanitize logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.ignore
 build

--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -132,7 +132,7 @@ class Identifier : public Expression {
  public:
   std::string value;
 
-  Identifier(std::string value) : value(value){};
+  Identifier(std::string value);
   Identifier(const Identifier& rhs) : value(rhs.value){};
   auto clone() const { return std::unique_ptr<Identifier>(clone_impl()); }
 

--- a/src/verilogAST.cpp
+++ b/src/verilogAST.cpp
@@ -71,7 +71,7 @@ std::string NumericLiteral::toString() {
   return size_str + separator + signed_str + radix_str + value;
 }
 
-std::string Identifier::toString() {
+Identifier::Identifier(std::string value) {
   static std::unordered_set<std::string> sKeywords{
       // clang-format off
       "accept_on",     "dist",          "local",                "randomize",       "task",
@@ -121,11 +121,13 @@ std::string Identifier::toString() {
       // clang-format on
   };
   static std::regex sSimpleIdentifierRE{"^[a-zA-Z$_][a-zA-Z$_0-9]*$"};
-  if (sKeywords.count(value) || !std::regex_match(value, sSimpleIdentifierRE))
-    return "\\" + value + " ";
-  else
-    return value;
+  if (sKeywords.count(value) || !std::regex_match(value, sSimpleIdentifierRE)) {
+    value = "\\" + value + " ";
+  }
+  this->value = value;
 }
+
+std::string Identifier::toString() { return this->value; }
 
 std::string Cast::toString() {
   return std::to_string(this->width) + "'(" + this->expr->toString() + ")";


### PR DESCRIPTION
Instead of performing the map lookup and regex every time we call
toString, instead just do it once when creating the ID node.  This
should improve performance for code that uses toString multiple times
for identifiers (e.g. in AssignInliner we do this to populate and lookup
entries in a map)

We also may consider making this optional (via a flag to the
constructor, or as a pass that traverses the tree and sanitizes
identifiers) to further improve performance (IIRC there's some valid
CoreIR names that are invalid verilog, so we'd want to make sure we're
enforcing valid verilog names downstream before making this change).