### PR TITLE
Fix error in Cast copy constructor

### DIFF
--- a/include/verilogAST.hpp
+++ b/include/verilogAST.hpp
@@ -115,7 +115,7 @@ class Cast : public Expression {
 
   Cast(unsigned int width, std::unique_ptr<Expression> expr)
       : width(width), expr(std::move(expr)){};
-  Cast(const Cast& rhs) : width(rhs.width), expr(expr->clone()){};
+  Cast(const Cast& rhs) : width(rhs.width), expr(rhs.expr->clone()){};
   auto clone() const { return std::unique_ptr<Cast>(clone_impl()); }
 
   std::string toString() override;


### PR DESCRIPTION
Fixes a clang error that wasn't present in older versions (not sure how
this worked before)
```
verilogAST-src/include/verilogAST.hpp:118:50: error: field 'expr' is uninitialized when used here [-Werror,-Wuninitialized]
  Cast(const Cast& rhs) : width(rhs.width), expr(expr->clone()){};
```